### PR TITLE
Initialization and uptime refactoring

### DIFF
--- a/manual_tests/delay_comms_test/delay_comms_test.c
+++ b/manual_tests/delay_comms_test/delay_comms_test.c
@@ -24,9 +24,9 @@ int main(void) {
 
     // comms_time_s = 0;
     // print("set comms_time_s = %lu\n", comms_time_s);
-    
-    comms_time_threshold_s = 10 * 60;
-    print("set comms_time_threshold_s = %lu\n", comms_time_threshold_s);
+
+    comms_thresh_s = 4 * 60;
+    print("set comms_thresh_s = %lu\n", comms_thresh_s);
     delay_comms();
 
     print("\nDone delay comms test\n\n\n");

--- a/manual_tests/delay_comms_test/makefile
+++ b/manual_tests/delay_comms_test/makefile
@@ -1,3 +1,3 @@
 PROG = delay_comms_test
-SRC = $(addprefix ../../src/,can_commands.c can_interface.c commands.c general.c mem.c rtc.c transceiver.c)
+SRC = $(addprefix ../../src/,can_commands.c can_interface.c commands.c general.c mem.c rtc.c transceiver.c uptime.c)
 include ../makefile

--- a/manual_tests/uptime_test/makefile
+++ b/manual_tests/uptime_test/makefile
@@ -1,0 +1,3 @@
+PROG = uptime_test
+SRC = $(addprefix ../../src/, uptime.c)
+include ../makefile

--- a/manual_tests/uptime_test/makefile
+++ b/manual_tests/uptime_test/makefile
@@ -1,3 +1,3 @@
 PROG = uptime_test
-SRC = $(addprefix ../../src/, uptime.c)
+SRC = $(addprefix ../../src/, general.c uptime.c)
 include ../makefile

--- a/manual_tests/uptime_test/uptime_test.c
+++ b/manual_tests/uptime_test/uptime_test.c
@@ -1,0 +1,21 @@
+/*
+This program tests initialization of the restart count (read EEPROM, increment,
+write EEPROM) and continuous updating of the OBC uptime.
+*/
+
+#include "../../src/uptime.h"
+
+int main(void) {
+    init_uart();
+
+    print("\n\n\nStarting uptime test\n\n");
+
+    init_restart_count();
+    print("restart_count = %lu\n", restart_count);
+    print("uptime_s = %lu\n", uptime_s);
+
+    start_uptime_timer();
+    print("Started uptime timer\n");
+
+    while (1) {}
+}

--- a/manual_tests/uptime_test/uptime_test.c
+++ b/manual_tests/uptime_test/uptime_test.c
@@ -17,5 +17,6 @@ int main(void) {
     start_uptime_timer();
     print("Started uptime timer\n");
 
+    // Make sure the program doesn't end here
     while (1) {}
 }

--- a/src/general.c
+++ b/src/general.c
@@ -59,12 +59,13 @@ void delay_comms(void) {
 
     // Use delays as a backup to the timer (upper bound)
     // Use 100ms increments because that it tolerable for delay precision
-    // print("Starting delay loop\n");
     // Use the constant COMMS_TIME_DELAY as a backup,
     // but use the modifiable comms_thresh_s as the intended condition
 
     // Keep a cached (saved) version of the global OBC uptime
     uint32_t cached_uptime_s = uptime_s;
+
+    // print("Starting delay loop\n");
 
     // Multiply by 10 because we are using delays of 1/10 seconds
     for (uint32_t i = 0; (i < COMMS_TIME_DELAY * 10) &&
@@ -77,6 +78,8 @@ void delay_comms(void) {
             uint32_t diff = uptime_s - cached_uptime_s;
             comms_time_s += diff;
             comms_eeprom_update_time_s += diff;
+
+            cached_uptime_s = uptime_s;
 
             print("Updated comms_time_s = %lu\n", comms_time_s);
             print("Updated comms_eeprom_update_time_s = %lu\n",

--- a/src/general.c
+++ b/src/general.c
@@ -1,26 +1,11 @@
 #include "general.h"
 
-// All time-related variables must be volatile since they are modified inside
-// the timer interrupt
-// Note that 1 billion seconds is about 31.7 years
-
-// Number of times OBC has started up (includes 1 for the first time)
-volatile uint32_t restart_count = 0;
-// OBC uptime (in seconds) - since most recent restart
-volatile uint32_t uptime_s = 0;
-
-// Set to true if we are currently inside the function `delay_comms()`
-// (in the process of waiting to init comms)
-volatile bool delaying_comms = false;
 // Count up to the time we can initialize comms - preserved between restarts
 volatile uint32_t comms_time_s = 0;
 // The threshold time that comms_time_s is counting up to
-volatile uint32_t comms_time_threshold_s = COMMS_TIME_DELAY;
+volatile uint32_t comms_thresh_s = COMMS_TIME_DELAY;
 // Number of seconds since we last updated comms time in EEPROM
 volatile uint32_t comms_eeprom_update_time_s = 0;
-
-
-void timer_cb_1m(void);
 
 
 // Initializes everything in OBC, EXCEPT the transceiver/comms things that must
@@ -46,26 +31,10 @@ void init_obc_core(void) {
     init_tx_mob(&pay_cmd_tx_mob);
     init_tx_mob(&eps_cmd_tx_mob);
 
-    // Read the restart count stored in EEPROM
-    restart_count = eeprom_read_dword(RESTART_COUNT_EEPROM_ADDR);
-    if (restart_count == EEPROM_DEF_DWORD) {
-        restart_count = 0;
-    }
-    // Increment the restart count and write it back to EEPROM
-    restart_count++;
-    eeprom_write_dword(RESTART_COUNT_EEPROM_ADDR, restart_count);
+    init_comms_time();
 
-    // Read the comms time stored in EEPROM
-    comms_time_s = eeprom_read_dword(COMMS_TIME_EEPROM_ADDR);
-    // If the EEPROM is cleared (read default all 1's), we know that we have not
-    // written to this address yet and the existing value should be ignored
-    if (comms_time_s == EEPROM_DEF_DWORD) {
-        comms_time_s = 0;
-    }
-
-    // TODO - use 1 second
-    // Initialize timer to go off every minute
-    init_timer_8bit(1, timer_cb_1m);
+    init_restart_count();
+    start_uptime_timer();
 }
 
 // Initializes the comms/transceiver parts of OBC that must be delayed after initial startup
@@ -73,49 +42,56 @@ void init_obc_comms(void) {
     init_trans();
 }
 
+void init_comms_time(void) {
+    // Read the comms time stored in EEPROM
+    comms_time_s = eeprom_read_dword(COMMS_TIME_EEPROM_ADDR);
+    // If the EEPROM is cleared (read default all 1's), we know that we have not
+    // written to this address yet and the existing value should be ignored
+    if (comms_time_s == EEPROM_DEF_DWORD) {
+        comms_time_s = 0;
+    }
+}
+
 // Delays 30 minutes before we can init comms
 // Fetches previous value in EEPROM to see if we have already spent some time
 void delay_comms(void) {
     // print("Starting %s\n", __FUNCTION__);
-    delaying_comms = true;
 
     // Use delays as a backup to the timer (upper bound)
     // Use 100ms increments because that it tolerable for delay precision
     // print("Starting delay loop\n");
     // Use the constant COMMS_TIME_DELAY as a backup,
-    // but use the modifiable comms_time_threshold_s as the intended condition
+    // but use the modifiable comms_thresh_s as the intended condition
+
+    // Keep a cached (saved) version of the global OBC uptime
+    uint32_t cached_uptime_s = uptime_s;
+
+    // Multiply by 10 because we are using delays of 1/10 seconds
     for (uint32_t i = 0; (i < COMMS_TIME_DELAY * 10) &&
-            (comms_time_s < comms_time_threshold_s); i++) {
+            (comms_time_s < comms_thresh_s); i++) {
+
         _delay_ms(100);
 
-        // If enough time has elapsed to write the new time to EEPROM, do it
-        if (comms_eeprom_update_time_s >= COMMS_EEPROM_UPDATE_TIME_THRESH) {
+        // Check if the uptime has changed from what we have cached
+        if (uptime_s > cached_uptime_s) {
+            uint32_t diff = uptime_s - cached_uptime_s;
+            comms_time_s += diff;
+            comms_eeprom_update_time_s += diff;
+
+            print("Updated comms_time_s = %lu\n", comms_time_s);
+            print("Updated comms_eeprom_update_time_s = %lu\n",
+                comms_eeprom_update_time_s);
+        }
+
+        // If enough time has elapsed, save the time to EEPROM
+        if (comms_eeprom_update_time_s >= COMMS_TIME_EEPROM_UPDATE_THRESH) {
             eeprom_write_dword(COMMS_TIME_EEPROM_ADDR, comms_time_s);
             print("Wrote comms_time_s = %lu to EEPROM\n", comms_time_s);
             comms_eeprom_update_time_s = 0;
         }
     }
 
-    delaying_comms = false;
     // print("Done %s\n", __FUNCTION__);
-}
-
-// This timer should be called repeatedly (every minute) to keep track of uptime, etc.
-// TODO - should be every second
-void timer_cb_1m(void) {
-    print("1 min timer cb\n");
-
-    // TODO - 1s
-    uptime_s += 60;
-    print("uptime_s = %lu\n", uptime_s);
-
-    // Only do comms time things if we are in the process of delaying comms
-    // (this timer callback will keep being called for the entire lifetime of the satellite but this block should only execute in the first 30 minutes)
-    if (delaying_comms) {
-        // TODO - use 1s
-        comms_time_s += 60;
-        comms_eeprom_update_time_s += 60;
-    }
 }
 
 // If the command queue is not empty, dequeues the next command and executes it

--- a/src/general.h
+++ b/src/general.h
@@ -12,30 +12,23 @@
 #include "mem.h"
 #include "rtc.h"
 #include "transceiver.h"
-
-// EEPROM address for storing number of resets
-#define RESTART_COUNT_EEPROM_ADDR ((uint32_t*) 0x60)
+#include "uptime.h"
 
 // EEPROM address to store number of seconds - counting to comms init
 #define COMMS_TIME_EEPROM_ADDR ((uint32_t*) 0x34)
 // Threshold for number of seconds to wait before updating the value in EEPROM
-#define COMMS_EEPROM_UPDATE_TIME_THRESH 60
+#define COMMS_TIME_EEPROM_UPDATE_THRESH 60
 // Number of seconds to wait before initializing comms (30 minutes)
 #define COMMS_TIME_DELAY (30 * 60)
 
-// Default double word (4-byte) value in EEPROM
-#define EEPROM_DEF_DWORD 0xFFFFFFFF
 
-extern volatile uint32_t restart_count;
-extern volatile uint32_t uptime_s;
-
-extern volatile bool delaying_comms;
 extern volatile uint32_t comms_time_s;
-extern volatile uint32_t comms_time_threshold_s;
+extern volatile uint32_t comms_thresh_s;
 extern volatile uint32_t comms_eeprom_update_time_s;
 
 void init_obc_core(void);
 void init_obc_comms(void);
+void init_comms_time(void);
 void delay_comms(void);
 
 void execute_next_cmd(void);

--- a/src/uptime.c
+++ b/src/uptime.c
@@ -1,0 +1,46 @@
+/*
+Functionality to track a global uptime (in seconds since last restart) across
+all of OBC using the 8-bit timer. Also tracks the number of times OBC has
+restarted using EEPROM.
+*/
+
+#include "uptime.h"
+
+// All time-related variables must be volatile since they are modified inside
+// the timer interrupt
+// Note that 1 billion seconds is about 31.7 years
+
+// Number of times OBC has started up (includes 1 for the first time)
+volatile uint32_t restart_count = 0;
+// OBC uptime (in seconds) - since most recent restart
+volatile uint32_t uptime_s = 0;
+
+void uptime_timer_cb(void);
+
+
+void init_restart_count(void) {
+    // Read the restart count stored in EEPROM
+    restart_count = eeprom_read_dword(RESTART_COUNT_EEPROM_ADDR);
+    if (restart_count == EEPROM_DEF_DWORD) {
+        restart_count = 0;
+    }
+    // Increment the restart count and write it back to EEPROM
+    restart_count++;
+    eeprom_write_dword(RESTART_COUNT_EEPROM_ADDR, restart_count);
+}
+
+void start_uptime_timer(void) {
+    // TODO - use 1 second
+    // Initialize timer to go off every minute
+    init_timer_8bit(1, uptime_timer_cb);
+}
+
+// This timer should be called repeatedly (every minute) to keep track of uptime
+// TODO - should be every second
+void uptime_timer_cb(void) {
+    print("uptime timer cb\n");
+
+    // TODO - 1s
+    uptime_s += 60;
+    print("uptime_s = %lu\n", uptime_s);
+}

--- a/src/uptime.h
+++ b/src/uptime.h
@@ -1,0 +1,24 @@
+#ifndef UPTIME_H
+#define UPTIME_H
+
+#include <stdint.h>
+
+#include <avr/eeprom.h>
+
+#include <timer/timer.h>
+#include <uart/uart.h>
+
+// Default double word (4-byte) value in EEPROM
+// TODO - put in lib-common/utilities
+#define EEPROM_DEF_DWORD 0xFFFFFFFF
+
+// EEPROM address for storing number of resets
+#define RESTART_COUNT_EEPROM_ADDR ((uint32_t*) 0x60)
+
+extern volatile uint32_t restart_count;
+extern volatile uint32_t uptime_s;
+
+void init_restart_count(void);
+void start_uptime_timer(void);
+
+#endif


### PR DESCRIPTION
This branch was originally intended to implement transceiver UART RX, but the functionality for OBC initialization, uptime, and comms initialization had to be refactored first. There is now a global uptime variable which other libraries can track if they want for their own purposes. This reduces dependencies and makes it more modular.