### PR TITLE
Lib-common and CAN fixes

### DIFF
--- a/manual_tests/commands_test/commands_test.c
+++ b/manual_tests/commands_test/commands_test.c
@@ -13,7 +13,6 @@ If set to false, it simulate both the EPS and PAY PCBs responding to CAN message
 
 #include <stdbool.h>
 
-#include <adc/eps.h>
 #include <can/data_protocol.h>
 #include <conversions/conversions.h>
 #include <queue/queue.h>
@@ -136,7 +135,7 @@ void print_local_data_fn(void) {
     print_header(eps_hk_header);
 
     // print("Fields: ");
-    for (uint8_t i = 0; i < CAN_EPS_HK_GET_COUNT; i++) {
+    for (uint8_t i = 0; i < CAN_EPS_HK_FIELD_COUNT; i++) {
         print("0x%.6lX ", eps_hk_fields[i]);
     }
     print("\n");
@@ -184,9 +183,9 @@ void print_local_data_fn(void) {
     // print("Mag Z:");
     // print_imu_data(eps_hk_fields[CAN_EPS_HK_IMU_MAG_Z]);
     print("Bat Temp Setpt 1:");
-    print_therm_temp(eps_hk_fields[CAN_EPS_HK_GET_DAC1]);
+    print_therm_temp(eps_hk_fields[CAN_EPS_HK_HEAT_SP1]);
     print("Bat Temp Setpt 2:");
-    print_therm_temp(eps_hk_fields[CAN_EPS_HK_GET_DAC2]);
+    print_therm_temp(eps_hk_fields[CAN_EPS_HK_HEAT_SP2]);
 
     print("\nPAY HK:\n");
 
@@ -194,7 +193,7 @@ void print_local_data_fn(void) {
     print_header(pay_hk_header);
 
     // print("Fields: ");
-    for (uint8_t i = 0; i < CAN_PAY_HK_GET_COUNT; i++) {
+    for (uint8_t i = 0; i < CAN_PAY_HK_FIELD_COUNT; i++) {
         print("0x%.6lX ", pay_hk_fields[i]);
     }
     print("\n");
@@ -210,9 +209,9 @@ void print_local_data_fn(void) {
         print_therm_temp(pay_hk_fields[CAN_PAY_HK_THERM0 + i]);
     }
     print("Temp Setpt 1:");
-    print_therm_temp(pay_hk_fields[CAN_PAY_HK_GET_DAC1]);
+    print_therm_temp(pay_hk_fields[CAN_PAY_HK_HEAT_SP1]);
     print("Temp Setpt 2:");
-    print_therm_temp(pay_hk_fields[CAN_PAY_HK_GET_DAC2]);
+    print_therm_temp(pay_hk_fields[CAN_PAY_HK_HEAT_SP2]);
 
     print("\nPAY OPT:\n");
 
@@ -220,12 +219,12 @@ void print_local_data_fn(void) {
     print_header(pay_opt_header);
 
     // print("Fields: ");
-    for (uint8_t i = 0; i < CAN_PAY_SCI_GET_COUNT; i++) {
+    for (uint8_t i = 0; i < CAN_PAY_OPT_FIELD_COUNT; i++) {
         print("0x%.6lX ", pay_opt_fields[i]);
     }
     print("\n");
 
-    for (uint8_t i = 0; i < CAN_PAY_SCI_GET_COUNT; i++) {
+    for (uint8_t i = 0; i < CAN_PAY_OPT_FIELD_COUNT; i++) {
         print("Well %u: 0x%.6lX = %.6f %%\n", i, pay_opt_fields[i],
             ((double) pay_opt_fields[i]) / 0xFFFFFF * 100.0);
     }
@@ -293,15 +292,15 @@ void print_next_rx_msg(void) {
 
 void clear_local_data_fn(void) {
     clear_mem_header(&eps_hk_header);
-    for (uint8_t i = 0; i < CAN_EPS_HK_GET_COUNT; i++) {
+    for (uint8_t i = 0; i < CAN_EPS_HK_FIELD_COUNT; i++) {
         eps_hk_fields[i] = 0;
     }
     clear_mem_header(&pay_hk_header);
-    for (uint8_t i = 0; i < CAN_PAY_HK_GET_COUNT; i++) {
+    for (uint8_t i = 0; i < CAN_PAY_HK_FIELD_COUNT; i++) {
         pay_hk_fields[i] = 0;
     }
     clear_mem_header(&pay_opt_header);
-    for (uint8_t i = 0; i < CAN_PAY_SCI_GET_COUNT; i++) {
+    for (uint8_t i = 0; i < CAN_PAY_OPT_FIELD_COUNT; i++) {
         pay_opt_fields[i] = 0;
     }
 
@@ -375,7 +374,7 @@ void sim_send_next_eps_tx_msg(void) {
     // Can return early to not send a message back
     switch (tx_msg[1]) {
         case CAN_EPS_HK:
-            if (0 <= tx_msg[2] && tx_msg[2] < CAN_EPS_HK_GET_COUNT) {
+            if (0 <= tx_msg[2] && tx_msg[2] < CAN_EPS_HK_FIELD_COUNT) {
                 // All fields are 12-bit ADC data
                 populate_msg_data(rx_msg, rand_bits(12));
             } else {
@@ -420,8 +419,8 @@ void sim_send_next_pay_tx_msg(void) {
             } else if (CAN_PAY_HK_THERM0 <= tx_msg[2] &&
                     tx_msg[2] < CAN_PAY_HK_THERM0 + 10) {
                 populate_msg_data(rx_msg, rand_bits(12));
-            } else if (tx_msg[2] == CAN_PAY_HK_GET_DAC1 ||
-                    tx_msg[2] == CAN_PAY_HK_GET_DAC2) {
+            } else if (tx_msg[2] == CAN_PAY_HK_HEAT_SP1 ||
+                    tx_msg[2] == CAN_PAY_HK_HEAT_SP2) {
                 populate_msg_data(rx_msg, rand_bits(12));
             } else {
                 return;
@@ -429,7 +428,7 @@ void sim_send_next_pay_tx_msg(void) {
             break;
 
         case CAN_PAY_OPT:
-            if (0 <= tx_msg[2] && tx_msg[2] < CAN_PAY_SCI_GET_COUNT) {
+            if (0 <= tx_msg[2] && tx_msg[2] < CAN_PAY_OPT_FIELD_COUNT) {
                 // All fields are 24-bit ADC data
                 populate_msg_data(rx_msg, rand_bits(24));
             } else {
@@ -437,8 +436,9 @@ void sim_send_next_pay_tx_msg(void) {
             }
             break;
 
-        case CAN_PAY_EXP:
-            if (tx_msg[2] == CAN_PAY_EXP_POP) {
+        // TODO
+        case CAN_PAY_CTRL:
+            if (tx_msg[2] == CAN_PAY_CTRL_ACT_UP) {
                 // Don't need to populate anything
             } else {
                 return;

--- a/src/can_commands.c
+++ b/src/can_commands.c
@@ -5,17 +5,17 @@ queue_t pay_tx_msg_queue;
 queue_t data_rx_msg_queue;
 
 mem_header_t eps_hk_header;
-uint32_t eps_hk_fields[CAN_EPS_HK_GET_COUNT] = { 0 };
+uint32_t eps_hk_fields[CAN_EPS_HK_FIELD_COUNT] = { 0 };
 mem_header_t pay_hk_header;
-uint32_t pay_hk_fields[CAN_PAY_HK_GET_COUNT] = { 0 };
+uint32_t pay_hk_fields[CAN_PAY_HK_FIELD_COUNT] = { 0 };
 mem_header_t pay_opt_header;
-uint32_t pay_opt_fields[CAN_PAY_SCI_GET_COUNT] = { 0 };
+uint32_t pay_opt_fields[CAN_PAY_OPT_FIELD_COUNT] = { 0 };
 
-
+void handle_eps_hk(const uint8_t* data);
+void handle_eps_ctrl(const uint8_t* data);
 void handle_pay_hk(const uint8_t* data);
 void handle_pay_opt(const uint8_t* data);
-void handle_eps_hk(const uint8_t* data);
-void handle_pay_motor(const uint8_t* data);
+void handle_pay_ctrl(const uint8_t* data);
 
 
 void handle_rx_msg(void) {
@@ -35,17 +35,20 @@ void handle_rx_msg(void) {
             case CAN_EPS_HK:
                 handle_eps_hk(data);
                 break;
+            case CAN_EPS_CTRL:
+                handle_eps_ctrl(data);
+                break;
             case CAN_PAY_HK:
                 handle_pay_hk(data);
                 break;
             case CAN_PAY_OPT:
                 handle_pay_opt(data);
                 break;
-            case CAN_PAY_EXP:
-                handle_pay_motor(data);
+            case CAN_PAY_CTRL:
+                handle_pay_ctrl(data);
                 break;
             default:
-                print("Invalid RX\n");
+                // print("Invalid RX\n");
                 break;
         }
     }
@@ -56,7 +59,7 @@ void handle_eps_hk(const uint8_t* data){
     uint8_t field_num = data[2];
 
     // Save the data to the local array
-    if (field_num < CAN_EPS_HK_GET_COUNT) {
+    if (field_num < CAN_EPS_HK_FIELD_COUNT) {
         // print("Received EPS_HK #%u\n", field_num);
         eps_hk_fields[field_num] =
                 (((uint32_t) data[3]) << 16) |
@@ -66,23 +69,33 @@ void handle_eps_hk(const uint8_t* data){
 
     // Request the next field (if not done yet)
     uint8_t next_field_num = field_num + 1;
-    if (next_field_num < CAN_EPS_HK_GET_COUNT) {
+    if (next_field_num < CAN_EPS_HK_FIELD_COUNT) {
         enqueue_eps_hk_tx_msg(next_field_num);
     }
 
     // If we have received all the fields
-    if ((current_cmd.fn == req_eps_hk_cmd.fn) && (field_num == CAN_EPS_HK_GET_COUNT - 1)) {
+    if ((current_cmd.fn == req_eps_hk_cmd.fn) && (field_num == CAN_EPS_HK_FIELD_COUNT - 1)) {
         print("Done EPS_HK\n");
         finish_current_cmd(true);
     }
 }
 
+// TODO
+void handle_eps_ctrl(const uint8_t* data){
+    // uint8_t field_num = data[2];
+    //
+    // // If we have received the field
+    // if ((current_cmd.fn == pop_blister_packs_cmd.fn) && (field_num == CAN_PAY_EXP_POP)) {
+    //     print("Done PAY_EXP_POP\n");
+    //     finish_current_cmd(true);
+    // }
+}
 
 void handle_pay_hk(const uint8_t* data){
     uint8_t field_num = data[2];
 
     // Save the data to the local array
-    if (field_num < CAN_PAY_HK_GET_COUNT) {
+    if (field_num < CAN_PAY_HK_FIELD_COUNT) {
         // print("modifying pay_hk_fields[%u]\n", field_num);
         pay_hk_fields[field_num] =
                 (((uint32_t) data[3]) << 16) |
@@ -91,12 +104,12 @@ void handle_pay_hk(const uint8_t* data){
     }
 
     uint8_t next_field_num = field_num + 1;
-    if (next_field_num < CAN_PAY_HK_GET_COUNT) {
+    if (next_field_num < CAN_PAY_HK_FIELD_COUNT) {
         enqueue_pay_hk_tx_msg(next_field_num);
     }
 
     // If we have received all the fields
-    if ((current_cmd.fn == req_pay_hk_cmd.fn) && (field_num == CAN_PAY_HK_GET_COUNT - 1)) {
+    if ((current_cmd.fn == req_pay_hk_cmd.fn) && (field_num == CAN_PAY_HK_FIELD_COUNT - 1)) {
         print("Done PAY_HK\n");
         finish_current_cmd(true);
     }
@@ -106,7 +119,7 @@ void handle_pay_opt(const uint8_t* data){
     uint8_t field_num = data[2];
 
     // Save the data to the local array
-    if (field_num < CAN_PAY_SCI_GET_COUNT) {
+    if (field_num < CAN_PAY_OPT_FIELD_COUNT) {
         // Save data
         pay_opt_fields[field_num] =
                 (((uint32_t) data[3]) << 16) |
@@ -115,25 +128,26 @@ void handle_pay_opt(const uint8_t* data){
     }
 
     uint8_t next_field_num = field_num + 1;
-    if (next_field_num < CAN_PAY_SCI_GET_COUNT){
+    if (next_field_num < CAN_PAY_OPT_FIELD_COUNT){
         enqueue_pay_opt_tx_msg(next_field_num);
     }
 
     // If we have received all the fields
-    if ((current_cmd.fn == req_pay_opt_cmd.fn) && (field_num == CAN_PAY_SCI_GET_COUNT - 1)) {
+    if ((current_cmd.fn == req_pay_opt_cmd.fn) && (field_num == CAN_PAY_OPT_FIELD_COUNT - 1)) {
         print("Done PAY_OPT\n");
         finish_current_cmd(true);
     }
 }
 
-void handle_pay_motor(const uint8_t* data){
-    uint8_t field_num = data[2];
-
-    // If we have received the field
-    if ((current_cmd.fn == pop_blister_packs_cmd.fn) && (field_num == CAN_PAY_EXP_POP)) {
-        print("Done PAY_EXP_POP\n");
-        finish_current_cmd(true);
-    }
+// TODO - fix actuation
+void handle_pay_ctrl(const uint8_t* data){
+    // uint8_t field_num = data[2];
+    //
+    // // If we have received the field
+    // if ((current_cmd.fn == pop_blister_packs_cmd.fn) && (field_num == CAN_PAY_EXP_POP)) {
+    //     print("Done PAY_EXP_POP\n");
+    //     finish_current_cmd(true);
+    // }
 }
 
 
@@ -158,12 +172,15 @@ void enqueue_tx_msg(queue_t* queue, uint8_t msg_type, uint8_t field_num) {
 void enqueue_eps_hk_tx_msg(uint8_t field_num) {
     enqueue_tx_msg(&eps_tx_msg_queue, CAN_EPS_HK, field_num);
 }
+void enqueue_eps_ctrl_tx_msg(uint8_t field_num) {
+    enqueue_tx_msg(&eps_tx_msg_queue, CAN_EPS_CTRL, field_num);
+}
 void enqueue_pay_hk_tx_msg(uint8_t field_num) {
     enqueue_tx_msg(&pay_tx_msg_queue, CAN_PAY_HK, field_num);
 }
 void enqueue_pay_opt_tx_msg(uint8_t field_num) {
     enqueue_tx_msg(&pay_tx_msg_queue, CAN_PAY_OPT, field_num);
 }
-void enqueue_pay_exp_tx_msg(uint8_t field_num) {
-    enqueue_tx_msg(&pay_tx_msg_queue, CAN_PAY_EXP, field_num);
+void enqueue_pay_ctrl_tx_msg(uint8_t field_num) {
+    enqueue_tx_msg(&pay_tx_msg_queue, CAN_PAY_CTRL, field_num);
 }

--- a/src/commands.c
+++ b/src/commands.c
@@ -82,7 +82,8 @@ void req_pay_opt_fn(void) {
 
 // Sends the command to actuate the motors
 void pop_blister_packs_fn(void) {
-    enqueue_pay_exp_tx_msg(CAN_PAY_EXP_POP);
+    // TODO
+    // enqueue_pay_exp_tx_msg(CAN_PAY_EXP_POP);
 }
 
 void write_mem_fn(void) {
@@ -118,7 +119,7 @@ void read_mem_fn(void) {
         eps_hk_header.time.hh = 18;
         eps_hk_header.time.mm = 5;
         eps_hk_header.time.ss = 20;
-        for (uint8_t i = 0; i < CAN_EPS_HK_GET_COUNT; i++) {
+        for (uint8_t i = 0; i < CAN_EPS_HK_FIELD_COUNT; i++) {
             eps_hk_fields[i] = i + 4;
         }
 
@@ -130,7 +131,7 @@ void read_mem_fn(void) {
         pay_hk_header.time.hh = 21;
         pay_hk_header.time.mm = 5;
         pay_hk_header.time.ss = 20;
-        for (uint8_t i = 0; i < CAN_PAY_HK_GET_COUNT; i++) {
+        for (uint8_t i = 0; i < CAN_PAY_HK_FIELD_COUNT; i++) {
             pay_hk_fields[i] = i + 17;
         }
 
@@ -142,7 +143,7 @@ void read_mem_fn(void) {
         pay_opt_header.time.hh = 4;
         pay_opt_header.time.mm = 5;
         pay_opt_header.time.ss = 20;
-        for (uint8_t i = 0; i < CAN_PAY_SCI_GET_COUNT; i++) {
+        for (uint8_t i = 0; i < CAN_PAY_OPT_FIELD_COUNT; i++) {
             pay_opt_fields[i] = i + 11;
         }
     }

--- a/src/general.c
+++ b/src/general.c
@@ -33,8 +33,9 @@ void init_obc_core(void) {
 
     init_comms_time();
 
-    init_restart_count();
-    start_uptime_timer();
+    rtc_date_t date = read_rtc_date();
+    rtc_time_t time = read_rtc_time();
+    init_uptime(date, time);
 }
 
 // Initializes the comms/transceiver parts of OBC that must be delayed after initial startup

--- a/src/mem.c
+++ b/src/mem.c
@@ -44,14 +44,14 @@ mem_section_t eps_hk_mem_section = {
     .start_addr = 0x0DB00UL,
     .curr_block = 0,
     .curr_block_eeprom_addr = (uint32_t*) 0x20,
-    .fields_per_block = CAN_EPS_HK_GET_COUNT   // Should be 12
+    .fields_per_block = CAN_EPS_HK_FIELD_COUNT   // Should be 12
 };
 
 mem_section_t pay_hk_mem_section = {
     .start_addr = 0x100000UL,
     .curr_block = 0,
     .curr_block_eeprom_addr = (uint32_t*) 0x24,
-    .fields_per_block = CAN_PAY_HK_GET_COUNT   // Should be 3
+    .fields_per_block = CAN_PAY_HK_FIELD_COUNT   // Should be 3
 };
 
 mem_section_t pay_opt_mem_section = {
@@ -59,7 +59,7 @@ mem_section_t pay_opt_mem_section = {
     .start_addr = 0x400000UL,
     .curr_block = 0,
     .curr_block_eeprom_addr = (uint32_t*) 0x28,
-    .fields_per_block = CAN_PAY_SCI_GET_COUNT   // Should be 36
+    .fields_per_block = CAN_PAY_OPT_FIELD_COUNT   // Should be 36
 };
 
 // All memory sections


### PR DESCRIPTION
Fixed errors from lib-common updates and CAN constant changes. `manual_tests/commands_test` is currently working (except for pop blister packs command).