### PR TITLE
Memory block number and EEPROM updates

### DIFF
--- a/harness_tests/mem/main1.c
+++ b/harness_tests/mem/main1.c
@@ -157,8 +157,6 @@ void eeprom_test(void) {
     inc_mem_section_curr_block(&pay_hk_mem_section);
     inc_mem_section_curr_block(&pay_opt_mem_section);
 
-    write_all_mem_sections_eeprom();
-
     ASSERT_EQ(eps_hk_block_prev + 1, eeprom_read_dword(eps_hk_mem_section.curr_block_eeprom_addr));
     ASSERT_EQ(pay_hk_block_prev + 1, eeprom_read_dword(pay_hk_mem_section.curr_block_eeprom_addr));
     ASSERT_EQ(pay_opt_block_prev + 1, eeprom_read_dword(pay_opt_mem_section.curr_block_eeprom_addr));

--- a/manual_tests/commands_test/commands_test.c
+++ b/manual_tests/commands_test/commands_test.c
@@ -177,7 +177,7 @@ void print_imu_data(uint16_t raw_data) {
 }
 
 void print_header(mem_header_t header) {
-    print("block_num = %u, error = %u, ", header.block_num, header.error);
+    print("block_num = %lu, error = %u, ", header.block_num, header.error);
     print("date = %02u:%02u:%02u, time = %02u:%02u:%02u\n",
         header.date.yy, header.date.mm, header.date.dd,
         header.time.hh, header.time.mm, header.time.ss);

--- a/manual_tests/mem_byte_test/makefile
+++ b/manual_tests/mem_byte_test/makefile
@@ -1,3 +1,3 @@
 PROG = mem_byte_test
-SRC = $(addprefix ../../src/,mem.c rtc.c)
+SRC = $(addprefix ../../src/,mem.c)
 include ../makefile

--- a/manual_tests/mem_section_test/mem_section_test.c
+++ b/manual_tests/mem_section_test/mem_section_test.c
@@ -30,13 +30,13 @@ void print_section(char* name, mem_section_t* section) {
 void print_sections(void) {
     print_section("EPS_HK", &eps_hk_mem_section);
     print_section("PAY_HK", &pay_hk_mem_section);
-    print_section("PAY_SCI", &pay_opt_mem_section);
+    print_section("PAY_OPT", &pay_opt_mem_section);
 }
 
 void print_header(mem_header_t* header) {
-    print("block_num = %u, error = %u, ",
+    print("block_num = %lu, error = %u, ",
         header->block_num, header->error);
-    print("date = %u %u %u, time = %u %u %u\n",
+    print("date = %u:%u:%u, time = %u:%u:%u\n",
         header->date.yy, header->date.mm, header->date.dd,
         header->time.hh, header->time.mm, header->time.ss);
 }
@@ -69,14 +69,12 @@ void test_eeprom(void) {
     inc_mem_section_curr_block(&eps_hk_mem_section);
     inc_mem_section_curr_block(&pay_hk_mem_section);
     inc_mem_section_curr_block(&pay_opt_mem_section);
-    write_all_mem_sections_eeprom();
     print("Incremented all current blocks, wrote to EEPROM\n");
 }
 
 
 void test_header(char* name, mem_section_t* section) {
     print("\nTesting %s section - header\n", name);
-
 
     mem_header_t write = {
         .block_num = section->curr_block,
@@ -143,17 +141,17 @@ int main(void) {
     /*
     What should happen in this test:
     1. Initializes all sections
-    2. Write field value: 0x070914 into PAY SCI section
-    3. Read back the same values from PAY SCI
+    2. Write field value: 0x070914 into PAY OPT section
+    3. Read back the same values from PAY OPT
     */
 
     test_header("EPS_HK", &eps_hk_mem_section);
     test_header("PAY_HK", &pay_hk_mem_section);
-    test_header("PAY_SCI", &pay_opt_mem_section);
+    test_header("PAY_OPT", &pay_opt_mem_section);
 
     test_field("EPS_HK", &eps_hk_mem_section);
     test_field("PAY_HK", &pay_hk_mem_section);
-    test_field("PAY_SCI", &pay_opt_mem_section);
+    test_field("PAY_OPT", &pay_opt_mem_section);
 
     print ("\n*** End of test ***\n");
 }

--- a/src/commands.c
+++ b/src/commands.c
@@ -526,7 +526,7 @@ void auto_data_col_timer_cb(void) {
 /*
 Populates the block number, error, and current live date/time.
 */
-void populate_header(mem_header_t* header, uint8_t block_num, uint8_t error) {
+void populate_header(mem_header_t* header, uint32_t block_num, uint8_t error) {
     header->block_num = block_num;
     header->error = error;
     if (sim_local_actions) {
@@ -544,10 +544,9 @@ void populate_header(mem_header_t* header, uint8_t block_num, uint8_t error) {
 
 
 void append_header_to_tx_msg(mem_header_t* header) {
-    // TODO - use 24 bits of block_num
-    append_to_trans_decoded_tx_msg(0);
-    append_to_trans_decoded_tx_msg(0);
-    append_to_trans_decoded_tx_msg(header->block_num);
+    append_to_trans_decoded_tx_msg((header->block_num >> 16) & 0xFF);
+    append_to_trans_decoded_tx_msg((header->block_num >> 8) & 0xFF);
+    append_to_trans_decoded_tx_msg(header->block_num & 0xFF);
     append_to_trans_decoded_tx_msg(header->error);
     append_to_trans_decoded_tx_msg(header->date.yy);
     append_to_trans_decoded_tx_msg(header->date.mm);

--- a/src/commands.h
+++ b/src/commands.h
@@ -81,7 +81,7 @@ extern cmd_t reset_cmd;
 void finish_current_cmd(bool succeeded);
 
 void auto_data_col_timer_cb(void);
-void populate_header(mem_header_t* header, uint8_t block_num, uint8_t error);
+void populate_header(mem_header_t* header, uint32_t block_num, uint8_t error);
 
 void append_header_to_tx_msg(mem_header_t* header);
 void append_fields_to_tx_msg(uint32_t* fields, uint8_t num_fields);

--- a/src/mem.c
+++ b/src/mem.c
@@ -144,11 +144,11 @@ void inc_mem_section_curr_block(mem_section_t* section) {
 
 
 
-void write_mem_block(mem_section_t* section, uint8_t block_num,
+void write_mem_block(mem_section_t* section, uint32_t block_num,
     mem_header_t* header, uint32_t* fields) {
 
     // print("%s: ", __FUNCTION__);
-    // print("start_addr = 0x%.8lX, block_num = %u\n", section->start_addr,
+    // print("start_addr = 0x%.8lX, block_num = %lu\n", section->start_addr,
     //     block_num);
 
     // Write header
@@ -159,11 +159,11 @@ void write_mem_block(mem_section_t* section, uint8_t block_num,
     }
 }
 
-void read_mem_block(mem_section_t* section, uint8_t block_num,
+void read_mem_block(mem_section_t* section, uint32_t block_num,
     mem_header_t* header, uint32_t* fields) {
 
     // print("%s: ", __FUNCTION__);
-    // print("start_addr = 0x%.8lX, block_num = %u\n", section->start_addr,
+    // print("start_addr = 0x%.8lX, block_num = %lu\n", section->start_addr,
     //     block_num);
 
     // Read header
@@ -177,7 +177,7 @@ void read_mem_block(mem_section_t* section, uint8_t block_num,
 
 
 
-void write_mem_header(mem_section_t* section, uint8_t block_num,
+void write_mem_header(mem_section_t* section, uint32_t block_num,
     mem_header_t* header) {
 
     /*
@@ -187,7 +187,9 @@ void write_mem_header(mem_section_t* section, uint8_t block_num,
     */
 
     uint8_t bytes[MEM_BYTES_PER_HEADER] = {
-        header->block_num,
+        (header->block_num >> 16) & 0xFF,
+        (header->block_num >> 8) & 0xFF,
+        header->block_num & 0xFF,
         header->error,
         header->date.yy, header->date.mm, header->date.dd,
         header->time.hh, header->time.mm, header->time.ss
@@ -203,21 +205,24 @@ block_num - the expected block number (determines the address to start reading
     from) - expected to be equal to header->block_num set by this function
 header - will be set by this function to the results
 */
-void read_mem_header(mem_section_t* section, uint8_t block_num,
+void read_mem_header(mem_section_t* section, uint32_t block_num,
     mem_header_t* header) {
 
     uint8_t bytes[MEM_BYTES_PER_HEADER];
     read_mem_bytes(mem_block_addr(section, block_num), bytes,
         MEM_BYTES_PER_HEADER);
 
-    header->block_num = bytes[0];
-    header->error = bytes[1];
-    header->date.yy = bytes[2];
-    header->date.mm = bytes[3];
-    header->date.dd = bytes[4];
-    header->time.hh = bytes[5];
-    header->time.mm = bytes[6];
-    header->time.ss = bytes[7];
+    header->block_num =
+        (((uint32_t) bytes[0]) << 16) |
+        (((uint32_t) bytes[1]) << 8) |
+        ((uint32_t) bytes[2]);
+    header->error = bytes[3];
+    header->date.yy = bytes[4];
+    header->date.mm = bytes[5];
+    header->date.dd = bytes[6];
+    header->time.hh = bytes[7];
+    header->time.mm = bytes[8];
+    header->time.ss = bytes[9];
 }
 
 

--- a/src/mem.c
+++ b/src/mem.c
@@ -81,6 +81,9 @@ void init_mem(void){
     }
 
     unlock_mem(); //use global unlock to unlock memory
+
+    // Read all previously stored EEPROM data
+    read_all_mem_sections_eeprom();
 }
 
 /*
@@ -101,46 +104,41 @@ void clear_mem_header(mem_header_t* header) {
     header->time.ss = 0;
 }
 
+
+
+/*
+writes the current block number of `section` to its designated address in EEPROM
+*/
 void write_mem_section_eeprom(mem_section_t* section) {
-    /*
-    writes the current block number of `section` to its designated address in EEPROM
-    */
     eeprom_write_dword (section->curr_block_eeprom_addr, section->curr_block);
 }
 
 /*
-Writes data for all memory sections to EEPROM.
+reads the current block number from its designated address in EEPROM and stores it in `section`
 */
-void write_all_mem_sections_eeprom(void) {
-    write_mem_section_eeprom(&eps_hk_mem_section);
-    write_mem_section_eeprom(&pay_hk_mem_section);
-    write_mem_section_eeprom(&pay_opt_mem_section);
-}
-
-
 void read_mem_section_eeprom(mem_section_t* section) {
-    /*
-    reads the current block number from its designated address in EEPROM and stores it in `section`
-    */
     section->curr_block = eeprom_read_dword (section->curr_block_eeprom_addr);
+    // TODO - constant
+    if (section->curr_block == 0xFFFFFFFF) {
+        section->curr_block = 0;
+    }
 }
 
 /*
 Reads data for all memory sections from EEPROM.
 */
 void read_all_mem_sections_eeprom(void) {
-    read_mem_section_eeprom(&eps_hk_mem_section);
-    read_mem_section_eeprom(&pay_hk_mem_section);
-    read_mem_section_eeprom(&pay_opt_mem_section);
+    for (uint8_t i = 0; i < MEM_NUM_SECTIONS; i++) {
+        read_mem_section_eeprom(all_mem_sections[i]);
+    }
 }
 
-
+/*
+Increments the section's current block number by 1 and writes it to EEPROM.
+*/
 void inc_mem_section_curr_block(mem_section_t* section) {
-    /*
-    Increments the section's current block number by 1.
-    NOTE: this DOES NOT update the value stored in EEPROM
-    */
     section->curr_block++;
+    write_mem_section_eeprom(section);
 }
 
 

--- a/src/mem.c
+++ b/src/mem.c
@@ -10,9 +10,6 @@ https://utat-ss.readthedocs.io/en/master/our-protocols/obc-mem.html
 
 Addresses are composed as follows (as uint32_t):
 { 0 (9 bits), chip_num (2 bits), chip_addr (21 bits)}
-
-TODO - make sure EEPROM addresses don't conflict with heartbeat
-TODO - develop harness-based test
 */
 
 #include "mem.h"
@@ -41,25 +38,24 @@ pin_info_t mem_cs[MEM_NUM_CHIPS] = {
 
 
 mem_section_t eps_hk_mem_section = {
-    .start_addr = 0x0DB00UL,
+    .start_addr = MEM_EPS_HK_START_ADDR,
     .curr_block = 0,
-    .curr_block_eeprom_addr = (uint32_t*) 0x20,
-    .fields_per_block = CAN_EPS_HK_FIELD_COUNT   // Should be 12
+    .curr_block_eeprom_addr = MEM_EPS_HK_CURR_BLOCK_EEPROM_ADDR,
+    .fields_per_block = CAN_EPS_HK_FIELD_COUNT
 };
 
 mem_section_t pay_hk_mem_section = {
-    .start_addr = 0x100000UL,
+    .start_addr = MEM_PAY_HK_START_ADDR,
     .curr_block = 0,
-    .curr_block_eeprom_addr = (uint32_t*) 0x24,
-    .fields_per_block = CAN_PAY_HK_FIELD_COUNT   // Should be 3
+    .curr_block_eeprom_addr = MEM_PAY_HK_CURR_BLOCK_EEPROM_ADDR,
+    .fields_per_block = CAN_PAY_HK_FIELD_COUNT
 };
 
 mem_section_t pay_opt_mem_section = {
-    // TODO - should be 0x200000
-    .start_addr = 0x400000UL,
+    .start_addr = MEM_PAY_OPT_START_ADDR,
     .curr_block = 0,
-    .curr_block_eeprom_addr = (uint32_t*) 0x28,
-    .fields_per_block = CAN_PAY_OPT_FIELD_COUNT   // Should be 36
+    .curr_block_eeprom_addr = MEM_PAY_OPT_CURR_BLOCK_EEPROM_ADDR,
+    .fields_per_block = CAN_PAY_OPT_FIELD_COUNT
 };
 
 // All memory sections

--- a/src/mem.h
+++ b/src/mem.h
@@ -12,43 +12,6 @@
 
 #include "rtc.h"
 
-// Sections in memory
-typedef struct {
-    // Start address of section in memory
-    uint32_t start_addr;
-    // Current block number being written to in this section of memory (starting from 0, increasing by 1)
-    uint32_t curr_block;
-    // Address in EEPROM that stores the current block number
-    uint32_t* curr_block_eeprom_addr;
-    // Number of fields in one block (NOT including the header/RTC data)
-    uint16_t fields_per_block;
-} mem_section_t;
-
-// A collection of the data for one header in memory
-typedef struct {
-    // Block number within section
-    // TODO - should it be 32-bit?
-    uint8_t block_num;
-    // Error data - TODO
-    uint8_t error;
-    // RTC data
-    rtc_date_t date;
-    // RTC time
-    rtc_time_t time;
-} mem_header_t;
-
-// Make the memory sections visible to other files so they can write data to sections
-extern mem_section_t eps_hk_mem_section;
-extern mem_section_t pay_hk_mem_section;
-extern mem_section_t pay_opt_mem_section;
-extern mem_section_t* all_mem_sections[];
-
-// Chips are numbered 0-2
-#define MEM_NUM_CHIPS 3
-
-// The number of bits used to address all bytes in one chip
-// Because one chip is 2MB and each adddress is for one byte
-#define MEM_CHIP_ADDR_WIDTH 21
 
 // Pins and Ports
 #define MEM_CS_PORT         PORTB
@@ -82,6 +45,14 @@ extern mem_section_t* all_mem_sections[];
 #define MEM_AAI     6
 #define MEM_BPL     7
 
+
+// Chips are numbered 0-2
+#define MEM_NUM_CHIPS 3
+
+// The number of bits used to address all bytes in one chip
+// Because one chip is 2MB and each adddress is for one byte
+#define MEM_CHIP_ADDR_WIDTH 21
+
 // Number of sections in memory layout
 #define MEM_NUM_SECTIONS 3
 // Number of bytes in a header
@@ -98,13 +69,44 @@ extern mem_section_t* all_mem_sections[];
 #define MEM_PAY_OPT_CURR_BLOCK_EEPROM_ADDR  ((uint32_t*) 0x28)
 
 
+// Sections in memory
+typedef struct {
+    // Start address of section in memory
+    uint32_t start_addr;
+    // Current block number being written to in this section of memory (starting from 0, increasing by 1)
+    uint32_t curr_block;
+    // Address in EEPROM that stores the current block number
+    uint32_t* curr_block_eeprom_addr;
+    // Number of fields in one block (NOT including the header/RTC data)
+    uint16_t fields_per_block;
+} mem_section_t;
+
+// A collection of the data for one header in memory
+typedef struct {
+    // Block number within section
+    // TODO - should it be 32-bit?
+    uint8_t block_num;
+    // Error data - TODO
+    uint8_t error;
+    // RTC data
+    rtc_date_t date;
+    // RTC time
+    rtc_time_t time;
+} mem_header_t;
+
+// Make the memory sections visible to other files so they can write data to sections
+extern mem_section_t eps_hk_mem_section;
+extern mem_section_t pay_hk_mem_section;
+extern mem_section_t pay_opt_mem_section;
+extern mem_section_t* all_mem_sections[];
+
+
 // Initialization
 void init_mem(void);
 void clear_mem_header(mem_header_t* header);
 
 // EEPROM
 void write_mem_section_eeprom(mem_section_t* section);
-void write_all_mem_sections_eeprom(void);
 void read_mem_section_eeprom(mem_section_t* section);
 void read_all_mem_sections_eeprom(void);
 void inc_mem_section_curr_block(mem_section_t* section);

--- a/src/mem.h
+++ b/src/mem.h
@@ -45,20 +45,17 @@
 #define MEM_AAI     6
 #define MEM_BPL     7
 
-
 // Chips are numbered 0-2
-#define MEM_NUM_CHIPS 3
-
+#define MEM_NUM_CHIPS           3
 // The number of bits used to address all bytes in one chip
 // Because one chip is 2MB and each adddress is for one byte
-#define MEM_CHIP_ADDR_WIDTH 21
-
+#define MEM_CHIP_ADDR_WIDTH     21
 // Number of sections in memory layout
-#define MEM_NUM_SECTIONS 3
+#define MEM_NUM_SECTIONS        3
 // Number of bytes in a header
-#define MEM_BYTES_PER_HEADER 8
+#define MEM_BYTES_PER_HEADER    10
 // Number of bytes in one field (one measurement)
-#define MEM_BYTES_PER_FIELD 3
+#define MEM_BYTES_PER_FIELD     3
 
 #define MEM_EPS_HK_START_ADDR   0x000000UL
 #define MEM_PAY_HK_START_ADDR   0x200000UL
@@ -77,15 +74,14 @@ typedef struct {
     uint32_t curr_block;
     // Address in EEPROM that stores the current block number
     uint32_t* curr_block_eeprom_addr;
-    // Number of fields in one block (NOT including the header/RTC data)
-    uint16_t fields_per_block;
+    // Number of fields in one block (NOT including the header)
+    uint8_t fields_per_block;
 } mem_section_t;
 
 // A collection of the data for one header in memory
 typedef struct {
     // Block number within section
-    // TODO - should it be 32-bit?
-    uint8_t block_num;
+    uint32_t block_num;
     // Error data - TODO
     uint8_t error;
     // RTC data
@@ -112,15 +108,15 @@ void read_all_mem_sections_eeprom(void);
 void inc_mem_section_curr_block(mem_section_t* section);
 
 // High-level operations - blocks
-void write_mem_block(mem_section_t* section, uint8_t block_num,
+void write_mem_block(mem_section_t* section, uint32_t block_num,
     mem_header_t* header, uint32_t* fields);
-void read_mem_block(mem_section_t* section, uint8_t block_num,
+void read_mem_block(mem_section_t* section, uint32_t block_num,
     mem_header_t* header, uint32_t* fields);
 
 // High-level operations - headers and fields
-void write_mem_header(mem_section_t* section, uint8_t block_num,
+void write_mem_header(mem_section_t* section, uint32_t block_num,
     mem_header_t* header);
-void read_mem_header(mem_section_t* section, uint8_t block_num,
+void read_mem_header(mem_section_t* section, uint32_t block_num,
     mem_header_t* header);
 void write_mem_field(mem_section_t* section, uint32_t block_num,
     uint8_t field_num, uint32_t data);

--- a/src/mem.h
+++ b/src/mem.h
@@ -51,7 +51,6 @@ extern mem_section_t* all_mem_sections[];
 #define MEM_CHIP_ADDR_WIDTH 21
 
 // Pins and Ports
-// TODO - change
 #define MEM_CS_PORT         PORTB
 #define MEM_CS_DDR          DDRB
 #define MEM_CHIP0_CS_PIN    PB2
@@ -89,6 +88,14 @@ extern mem_section_t* all_mem_sections[];
 #define MEM_BYTES_PER_HEADER 8
 // Number of bytes in one field (one measurement)
 #define MEM_BYTES_PER_FIELD 3
+
+#define MEM_EPS_HK_START_ADDR   0x000000UL
+#define MEM_PAY_HK_START_ADDR   0x200000UL
+#define MEM_PAY_OPT_START_ADDR  0x300000UL
+
+#define MEM_EPS_HK_CURR_BLOCK_EEPROM_ADDR   ((uint32_t*) 0x20)
+#define MEM_PAY_HK_CURR_BLOCK_EEPROM_ADDR   ((uint32_t*) 0x24)
+#define MEM_PAY_OPT_CURR_BLOCK_EEPROM_ADDR  ((uint32_t*) 0x28)
 
 
 // Initialization


### PR DESCRIPTION
- Changed block number representation from `uint8_t` to `uint32_t`
- Changed header from 8 to 10 bytes (3 bytes instead of 1 byte for block number)
- Made EEPROM updates automatic with incrementing block numbers
- Defined new constants
- General cleanup
