### PR TITLE
Removed code that performed an unnecessary extra write to EEPROM

### DIFF
--- a/src/can_commands.c
+++ b/src/can_commands.c
@@ -95,8 +95,8 @@ void handle_eps_hk(uint8_t field_num, uint32_t data){
             write_mem_data_block(&eps_hk_mem_section, eps_hk_mem_section.curr_block,
                 &eps_hk_header, eps_hk_fields);
         }
+        // Increment the current block and then write to the section
         inc_mem_section_curr_block(&eps_hk_mem_section);
-        write_mem_section_eeprom(&eps_hk_mem_section);
 
         print("Done EPS_HK\n");
         finish_current_cmd(true);
@@ -125,8 +125,8 @@ void handle_pay_hk(uint8_t field_num, uint32_t data){
             write_mem_data_block(&pay_hk_mem_section, pay_hk_mem_section.curr_block,
                 &pay_hk_header, pay_hk_fields);
         }
-        inc_mem_section_curr_block(&pay_hk_mem_section);
-        write_mem_section_eeprom(&pay_hk_mem_section);
+        // Increment the current block and then write to the section
+        inc_mem_section_curr_block(&eps_hk_mem_section);
 
         print("Done PAY_HK\n");
         finish_current_cmd(true);
@@ -154,8 +154,8 @@ void handle_pay_opt(uint8_t field_num, uint32_t data){
             write_mem_data_block(&pay_opt_mem_section, pay_opt_mem_section.curr_block,
                 &pay_opt_header, pay_opt_fields);
         }
-        inc_mem_section_curr_block(&pay_opt_mem_section);
-        write_mem_section_eeprom(&pay_opt_mem_section);
+        // Increment the current block and then write to the section
+        inc_mem_section_curr_block(&eps_hk_mem_section);
 
         print("Done PAY_OPT\n");
         finish_current_cmd(true);


### PR DESCRIPTION
- Calling inc_mem_section_curr_block(mem_section_t* section) and then write_mem_section_eeprom(mem_section_t* section) performed one increment and two writes. 

- Removed write_mem_section_eeprom so that only one write would occur, as expected