### PR TITLE
Command cleanup

### DIFF
--- a/harness_tests/mem/main1.c
+++ b/harness_tests/mem/main1.c
@@ -245,7 +245,8 @@ void mem_header_test_individual( mem_section_t* section ) {
         .time = rand_rtc_time(),
         .status = 0x00,
     };
-    write_mem_header(section, section->curr_block, &write);
+    write_mem_header_main(section, section->curr_block, &write);
+    write_mem_header_status(section, section->curr_block, write.status);
 
     mem_header_t read;
     read_mem_header(section, section->curr_block, &read);

--- a/harness_tests/mem/main1.c
+++ b/harness_tests/mem/main1.c
@@ -542,6 +542,7 @@ void cmd_block_test(void) {
     write_arg1 = 1000000000;
     write_arg2 = 132497;
     ASSERT_TRUE(write_mem_cmd_block(&prim_cmd_log_mem_section, block_num, &write_header, write_cmd_num, write_arg1, write_arg2));
+    write_mem_header_status(&prim_cmd_log_mem_section, block_num, write_header.status);
 
     read_mem_cmd_block(&prim_cmd_log_mem_section, block_num, &read_header, &read_cmd_num, &read_arg1, &read_arg2);
     ASSERT_EQ(write_header.block_num, read_header.block_num);
@@ -554,6 +555,7 @@ void cmd_block_test(void) {
 
     block_num = 1000000;
     ASSERT_FALSE(write_mem_cmd_block(&prim_cmd_log_mem_section, block_num, &write_header, write_cmd_num, write_arg1, write_arg2));
+    write_mem_header_status(&prim_cmd_log_mem_section, block_num, write_header.status);
 }
 
 /* Test the ability to erase a 4kb sector of memory given an address */

--- a/manual_tests/main_test/main_test.c
+++ b/manual_tests/main_test/main_test.c
@@ -339,6 +339,11 @@ void sim_send_next_eps_tx_msg(void) {
     uint8_t tx_msg[8] = {0x00};
     dequeue(&eps_tx_msg_queue, tx_msg);
 
+    if (print_can_msgs) {
+        print("CAN TX (EPS): ");
+        print_bytes(tx_msg, 8);
+    }
+
     // Construct the message EPS would send back
     uint8_t rx_msg[8] = {0x00};
     rx_msg[0] = 0x00;
@@ -400,6 +405,11 @@ void sim_send_next_pay_tx_msg(void) {
     // TX and RX defined from OBC's perspective
     uint8_t tx_msg[8] = {0x00};
     dequeue(&pay_tx_msg_queue, tx_msg);
+
+    if (print_can_msgs) {
+        print("CAN TX (PAY): ");
+        print_bytes(tx_msg, 8);
+    }
 
     // Construct the message EPS would send back
     uint8_t rx_msg[8] = {0x00};

--- a/manual_tests/main_test/main_test.c
+++ b/manual_tests/main_test/main_test.c
@@ -253,7 +253,7 @@ void print_local_data_fn(void) {
             ((double) pay_opt_fields[i]) / 0xFFFFFF * 100.0);
     }
 
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 
@@ -424,7 +424,7 @@ void clear_local_data_fn(void) {
 
     print("Cleared local data\n");
 
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void read_all_mem_blocks_to_local_fn(void) {
@@ -436,7 +436,7 @@ void read_all_mem_blocks_to_local_fn(void) {
     enqueue_cmd(&read_data_block_cmd, CMD_PAY_OPT,
         pay_opt_mem_section.curr_block - 1);
 
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 

--- a/manual_tests/main_test/main_test.c
+++ b/manual_tests/main_test/main_test.c
@@ -39,15 +39,6 @@ bool skip_deploy_antenna = false;
 
 bool disable_hb = false;
 
-// Set to true to print TX and RX CAN messages
-bool print_can_msgs = false;
-// Set to true to print commands and arguments
-bool print_cmds = false;
-// Set to true to print transceiver messages
-bool print_trans_msgs = false;
-// Set to true to print ACKs
-bool print_trans_tx_acks = false;
-
 
 // Normal command with a string description to print on UART
 typedef struct {
@@ -255,155 +246,6 @@ void print_local_data_fn(void) {
 
     finish_current_cmd(CMD_RESP_STATUS_OK);
 }
-
-
-
-
-void print_next_eps_tx_msg(void) {
-    if (!print_can_msgs) {
-        return;
-    }
-
-    uint8_t tx_msg[8] = { 0x00 };
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        if (queue_empty(&eps_tx_msg_queue)) {
-            return;
-        }
-        peek_queue(&eps_tx_msg_queue, tx_msg);
-    }
-
-    print("CAN TX (EPS): ");
-    print_bytes(tx_msg, 8);
-}
-
-void print_next_pay_tx_msg(void) {
-    if (!print_can_msgs) {
-        return;
-    }
-
-    uint8_t tx_msg[8] = { 0x00 };
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        if (queue_empty(&pay_tx_msg_queue)) {
-            return;
-        }
-        peek_queue(&pay_tx_msg_queue, tx_msg);
-    }
-
-    print("CAN TX (PAY): ");
-    print_bytes(tx_msg, 8);
-}
-
-void print_next_rx_msg(void) {
-    if (!print_can_msgs) {
-        return;
-    }
-
-    uint8_t rx_msg[8] = { 0x00 };
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        if (queue_empty(&data_rx_msg_queue)) {
-            return;
-        }
-        peek_queue(&data_rx_msg_queue, rx_msg);
-    }
-
-    // Extra spaces to align with CAN TX messages
-    print("CAN RX:       ");
-    print_bytes(rx_msg, 8);
-}
-
-void print_next_trans_tx_ack(void) {
-    if (!print_trans_tx_acks) {
-        return;
-    }
-
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        if (!trans_tx_ack_avail) {
-            return;
-        }
-        print("ACK: op = 0x%.2x, arg1 = 0x%.8lx, arg2 = 0x%.8lx, stat = 0x%.2x\n", trans_tx_ack_opcode, trans_tx_ack_arg1, trans_tx_ack_arg2, trans_tx_ack_status);
-    }
-}
-
-void print_next_cmd(void) {
-    if (!print_cmds) {
-        return;
-    }
-    // Only print if we are open to start a new command, or else it will spam
-    // print this in every main loop iteration until the current command is done
-    if (current_cmd != &nop_cmd) {
-        return;
-    }
-
-    uint8_t cmd[8] = { 0x00 };
-    uint8_t args[8] = { 0x00 };
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        if (queue_empty(&cmd_opcode_queue)) {
-            return;
-        }
-        if (queue_empty(&cmd_args_queue)) {
-            return;
-        }
-        peek_queue(&cmd_opcode_queue, cmd);
-        peek_queue(&cmd_args_queue, args);
-    }
-
-    print("Cmd:  ");
-    print_bytes(cmd, 8);
-    print("Args: ");
-    print_bytes(args, 8);
-}
-
-
-void print_next_trans_tx_enc_msg(void) {
-    if (!print_trans_msgs) {
-        return;
-    }
-    if (!trans_tx_enc_avail) {
-        return;
-    }
-
-    print("Trans TX (Encoded): %u bytes: ", trans_tx_enc_len);
-    print_bytes((uint8_t*) trans_tx_enc_msg, trans_tx_enc_len);
-}
-
-void print_next_trans_tx_dec_msg(void) {
-    if (!print_trans_msgs) {
-        return;
-    }
-    if (!trans_tx_dec_avail) {
-        return;
-    }
-
-    print("Trans TX (Decoded): %u bytes: ", trans_tx_dec_len);
-    print_bytes((uint8_t*) trans_tx_dec_msg, trans_tx_dec_len);
-}
-
-void print_next_trans_rx_dec_msg(void) {
-    if (!print_trans_msgs) {
-        return;
-    }
-    if (!trans_rx_dec_avail) {
-        return;
-    }
-
-    print("Trans RX (Decoded): %u bytes: ", trans_rx_dec_len);
-    print_bytes((uint8_t*) trans_rx_dec_msg, trans_rx_dec_len);
-}
-
-void print_next_trans_rx_enc_msg(void) {
-    if (!print_trans_msgs) {
-        return;
-    }
-    if (!trans_rx_enc_avail) {
-        return;
-    }
-
-    print("\n");
-    print("Trans RX (Encoded): %u bytes: ", trans_rx_enc_len);
-    print_bytes((uint8_t*) trans_rx_enc_msg, trans_rx_enc_len);
-}
-
-
 
 
 
@@ -779,75 +621,43 @@ int main(void){
         }
 
         // Trans RX (encoded)
-        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-            print_next_trans_rx_enc_msg();
-            decode_trans_rx_msg();
-        }
+        decode_trans_rx_msg();
         // Trans RX (decoded)
-        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-            print_next_trans_rx_dec_msg();
-            handle_trans_rx_dec_msg();
-        }
+        handle_trans_rx_dec_msg();
 
         // Trans TX ACK
-        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-            print_next_trans_tx_ack();
-            process_trans_tx_ack();
-        }
-        // TODO - better way to do this than to repeat TX twice in a loop iteration?
+        process_trans_tx_ack();
         // Trans TX (decoded)
-        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-            print_next_trans_tx_dec_msg();
-            encode_trans_tx_msg();
-        }
+        encode_trans_tx_msg();
         // Trans TX (encoded)
-        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-            print_next_trans_tx_enc_msg();
-            send_trans_tx_enc_msg();
-        }
+        send_trans_tx_enc_msg();
 
         // Command
-        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-            print_next_cmd();
-            execute_next_cmd();
-        }
+        execute_next_cmd();
 
         // EPS TX
-        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-            print_next_eps_tx_msg();
-            // Either simulate EPS over CAN or actually send the CAN message
-            if (sim_eps) {
-                sim_send_next_eps_tx_msg();
-            }  else {
-                send_next_eps_tx_msg();
-            }
-        }
-        // PAY TX
-        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-            print_next_pay_tx_msg();
-            // Either simulate PAY over CAN or actually send the CAN message
-            if (sim_pay) {
-                sim_send_next_pay_tx_msg();
-            }  else {
-                send_next_pay_tx_msg();
-            }
-        }
-        // EPS/PAY RX
-        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-            print_next_rx_msg();
-            process_next_rx_msg();
+        // Either simulate EPS over CAN or actually send the CAN message
+        if (sim_eps) {
+            sim_send_next_eps_tx_msg();
+        }  else {
+            send_next_eps_tx_msg();
         }
 
+        // PAY TX
+        // Either simulate PAY over CAN or actually send the CAN message
+        if (sim_pay) {
+            sim_send_next_pay_tx_msg();
+        }  else {
+            send_next_pay_tx_msg();
+        }
+
+        // EPS/PAY RX
+        process_next_rx_msg();
+
         // Trans TX (decoded)
-        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-            print_next_trans_tx_dec_msg();
-            encode_trans_tx_msg();
-        }
+        encode_trans_tx_msg();
         // Trans TX (encoded)
-        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-            print_next_trans_tx_enc_msg();
-            send_trans_tx_enc_msg();
-        }
+        send_trans_tx_enc_msg();
     }
 
     return 0;

--- a/manual_tests/mem_section_test/mem_section_test.c
+++ b/manual_tests/mem_section_test/mem_section_test.c
@@ -88,7 +88,8 @@ void test_header(char* name, mem_section_t* section) {
     print("Initial value in memory: ");
     print_header(&read);
 
-    write_mem_header(section, section->curr_block, &write);
+    write_mem_header_main(section, section->curr_block, &write);
+    write_mem_header_status(section, section->curr_block, write.status);
     print("Wrote header to memory: ");
     print_header(&write);
 

--- a/src/can_commands.c
+++ b/src/can_commands.c
@@ -1,5 +1,8 @@
 #include "can_commands.h"
 
+// Uncomment for extra debugging prints
+// #define CAN_COMMANDS_DEBUG
+
 queue_t eps_tx_msg_queue;
 queue_t pay_tx_msg_queue;
 queue_t data_rx_msg_queue;
@@ -22,7 +25,6 @@ void handle_rx_msg(void) {
     }
 
     uint8_t msg[8] = {0x00};
-    // print("Dequeued from data_rx_msg_queue\n");
     dequeue(&data_rx_msg_queue, msg);
 
     if (print_can_msgs) {
@@ -87,7 +89,6 @@ void handle_eps_hk(uint8_t field_num, uint32_t data){
 
     // Save the data to the local array and flash memory
     if (field_num < CAN_EPS_HK_FIELD_COUNT) {
-        // print("Received EPS_HK #%u\n", field_num);
         eps_hk_fields[field_num] = data;
         write_mem_field(&eps_hk_mem_section, eps_hk_header.block_num, field_num,
             data);
@@ -118,7 +119,9 @@ void handle_eps_hk(uint8_t field_num, uint32_t data){
             }
         }
 
+#ifdef CAN_COMMANDS_DEBUG
         print("Done EPS_HK\n");
+#endif
         finish_current_cmd(CMD_RESP_STATUS_OK);
     }
 }
@@ -134,7 +137,6 @@ void handle_pay_hk(uint8_t field_num, uint32_t data){
 
     // Save the data to the local array and flash memory
     if (field_num < CAN_PAY_HK_FIELD_COUNT) {
-        // print("modifying pay_hk_fields[%u]\n", field_num);
         pay_hk_fields[field_num] = data;
         write_mem_field(&pay_hk_mem_section, pay_hk_header.block_num, field_num,
             data);
@@ -164,7 +166,9 @@ void handle_pay_hk(uint8_t field_num, uint32_t data){
             }
         }
 
+#ifdef CAN_COMMANDS_DEBUG
         print("Done PAY_HK\n");
+#endif
         finish_current_cmd(CMD_RESP_STATUS_OK);
     }
 }
@@ -209,7 +213,9 @@ void handle_pay_opt(uint8_t field_num, uint32_t data){
             }
         }
 
+#ifdef CAN_COMMANDS_DEBUG
         print("Done PAY_OPT\n");
+#endif
         finish_current_cmd(CMD_RESP_STATUS_OK);
     }
 }

--- a/src/can_commands.c
+++ b/src/can_commands.c
@@ -32,13 +32,13 @@ void handle_rx_msg(void) {
     //General CAN command-Send back data
     if ((current_cmd == &send_eps_can_msg_cmd) || (current_cmd == &send_pay_can_msg_cmd)) {
         ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-            start_trans_tx_dec_msg(CMD_STATUS_OK);
+            start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
             for (uint8_t i = 0; i < 8; i++) {
                 append_to_trans_tx_dec_msg(msg[i]);
             }
             finish_trans_tx_dec_msg();
         }
-        finish_current_cmd(CMD_STATUS_OK);
+        finish_current_cmd(CMD_RESP_STATUS_OK);
     }
     else {
         switch (opcode) {
@@ -89,7 +89,7 @@ void handle_eps_hk(uint8_t field_num, uint32_t data){
         // ground (arg2 = 0)
         if (current_cmd_arg2 == 0) {
             ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-                start_trans_tx_dec_msg(CMD_STATUS_OK);
+                start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
                 append_to_trans_tx_dec_msg((eps_hk_mem_section.curr_block >> 24) & 0xFF);
                 append_to_trans_tx_dec_msg((eps_hk_mem_section.curr_block >> 16) & 0xFF);
                 append_to_trans_tx_dec_msg((eps_hk_mem_section.curr_block >> 8) & 0xFF);
@@ -99,7 +99,7 @@ void handle_eps_hk(uint8_t field_num, uint32_t data){
         }
 
         print("Done EPS_HK\n");
-        finish_current_cmd(CMD_STATUS_OK);
+        finish_current_cmd(CMD_RESP_STATUS_OK);
     }
 }
 
@@ -130,7 +130,7 @@ void handle_pay_hk(uint8_t field_num, uint32_t data){
         // ground (arg2 = 0)
         if (current_cmd_arg2 == 0) {
             ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-                start_trans_tx_dec_msg(CMD_STATUS_OK);
+                start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
                 append_to_trans_tx_dec_msg((pay_hk_mem_section.curr_block >> 24) & 0xFF);
                 append_to_trans_tx_dec_msg((pay_hk_mem_section.curr_block >> 16) & 0xFF);
                 append_to_trans_tx_dec_msg((pay_hk_mem_section.curr_block >> 8) & 0xFF);
@@ -140,7 +140,7 @@ void handle_pay_hk(uint8_t field_num, uint32_t data){
         }
 
         print("Done PAY_HK\n");
-        finish_current_cmd(CMD_STATUS_OK);
+        finish_current_cmd(CMD_RESP_STATUS_OK);
     }
 }
 
@@ -170,7 +170,7 @@ void handle_pay_opt(uint8_t field_num, uint32_t data){
         // ground (arg2 = 0)
         if (current_cmd_arg2 == 0) {
             ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-                start_trans_tx_dec_msg(CMD_STATUS_OK);
+                start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
                 append_to_trans_tx_dec_msg((pay_opt_mem_section.curr_block >> 24) & 0xFF);
                 append_to_trans_tx_dec_msg((pay_opt_mem_section.curr_block >> 16) & 0xFF);
                 append_to_trans_tx_dec_msg((pay_opt_mem_section.curr_block >> 8) & 0xFF);
@@ -180,7 +180,7 @@ void handle_pay_opt(uint8_t field_num, uint32_t data){
         }
 
         print("Done PAY_OPT\n");
-        finish_current_cmd(CMD_STATUS_OK);
+        finish_current_cmd(CMD_RESP_STATUS_OK);
     }
 }
 
@@ -189,9 +189,9 @@ void handle_pay_ctrl(uint8_t field_num) {
         field_num == CAN_PAY_CTRL_ACT_DOWN) &&
         current_cmd == &act_pay_motors_cmd) {
 
-        add_def_trans_tx_dec_msg(CMD_STATUS_OK);
+        add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
 
-        finish_current_cmd(CMD_STATUS_OK);
+        finish_current_cmd(CMD_RESP_STATUS_OK);
     }
 }
 

--- a/src/can_commands.c
+++ b/src/can_commands.c
@@ -103,10 +103,6 @@ void process_eps_hk(uint8_t field_num, uint32_t data){
 
     // If we have received all the fields
     if (field_num == CAN_EPS_HK_FIELD_COUNT - 1) {
-        // Successfully finished command
-        write_mem_header_status(&eps_hk_mem_section, eps_hk_header.block_num,
-            CMD_RESP_STATUS_OK);
-
         // Only send back a transceiver packet if the command was sent from
         // ground (arg2 = 0)
         if (current_cmd_arg2 == 0) {
@@ -149,11 +145,7 @@ void process_pay_hk(uint8_t field_num, uint32_t data){
     }
 
     // If we have received all the fields
-    if (field_num == CAN_PAY_HK_FIELD_COUNT - 1) {
-        // Successfully finished command
-        write_mem_header_status(&pay_hk_mem_section, pay_hk_header.block_num,
-            CMD_RESP_STATUS_OK);
-        
+    if (field_num == CAN_PAY_HK_FIELD_COUNT - 1) {        
         // Only send back a transceiver packet if the command was sent from
         // ground (arg2 = 0)
         if (current_cmd_arg2 == 0) {
@@ -196,11 +188,7 @@ void process_pay_opt(uint8_t field_num, uint32_t data){
     }
 
     // If we have received all the fields
-    if (field_num == CAN_PAY_OPT_FIELD_COUNT - 1) {
-        // Successfully finished command
-        write_mem_header_status(&pay_opt_mem_section, pay_opt_header.block_num,
-            CMD_RESP_STATUS_OK);
-        
+    if (field_num == CAN_PAY_OPT_FIELD_COUNT - 1) {        
         // Only send back a transceiver packet if the command was sent from
         // ground (arg2 = 0)
         if (current_cmd_arg2 == 0) {

--- a/src/can_commands.c
+++ b/src/can_commands.c
@@ -5,6 +5,10 @@ queue_t pay_tx_msg_queue;
 queue_t data_rx_msg_queue;
 
 
+// Set to true to print TX and RX CAN messages
+bool print_can_msgs = false;
+
+
 void handle_eps_hk(uint8_t field_num, uint32_t data);
 void handle_pay_hk(uint8_t field_num, uint32_t data);
 void handle_pay_opt(uint8_t field_num, uint32_t data);
@@ -21,6 +25,13 @@ void handle_rx_msg(void) {
     // print("Dequeued from data_rx_msg_queue\n");
     dequeue(&data_rx_msg_queue, msg);
 
+    if (print_can_msgs) {
+        // Extra spaces to align with CAN TX messages
+        print("CAN RX:       ");
+        print_bytes(msg, 8);
+    }
+
+    // Break down the message into components
     uint8_t opcode = msg[2];
     uint8_t field_num = msg[3];
     uint32_t data =
@@ -230,8 +241,16 @@ When resume_mob(mob name) is called, it:
 3) sends the data
 4) pauses the mob
 */
+// TODO - refactor?
 void send_next_eps_tx_msg(void) {
     if (!queue_empty(&eps_tx_msg_queue)) {
+        if (print_can_msgs) {
+            uint8_t tx_msg[8] = { 0x00 };
+            peek_queue(&eps_tx_msg_queue, tx_msg);
+            print("CAN TX (EPS): ");
+            print_bytes(tx_msg, 8);
+        }
+
         resume_mob(&eps_cmd_tx_mob);
     }
 }
@@ -247,6 +266,13 @@ When resume_mob(mob name) is called, it:
 */
 void send_next_pay_tx_msg(void) {
     if (!queue_empty(&pay_tx_msg_queue)) {
+        if (print_can_msgs) {
+            uint8_t tx_msg[8] = { 0x00 };
+            peek_queue(&pay_tx_msg_queue, tx_msg);
+            print("CAN TX (PAY): ");
+            print_bytes(tx_msg, 8);
+        }
+
         resume_mob(&pay_cmd_tx_mob);
     }
 }

--- a/src/can_commands.h
+++ b/src/can_commands.h
@@ -17,6 +17,8 @@ extern queue_t eps_tx_msg_queue;
 extern queue_t pay_tx_msg_queue;
 extern queue_t data_rx_msg_queue;
 
+extern bool print_can_msgs;
+
 
 void handle_rx_msg(void);
 

--- a/src/can_interface.c
+++ b/src/can_interface.c
@@ -1,5 +1,3 @@
-// TODO - define constants in lib-common for MOB numbers (0-5)
-
 #include "can_interface.h"
 
 void pay_cmd_tx_data_callback(uint8_t* data, uint8_t *len) {

--- a/src/can_interface.c
+++ b/src/can_interface.c
@@ -1,6 +1,6 @@
 #include "can_interface.h"
 
-void pay_cmd_tx_data_callback(uint8_t* data, uint8_t *len) {
+void pay_cmd_tx_callback(uint8_t* data, uint8_t *len) {
     if (queue_empty(&pay_tx_msg_queue)) {
         *len = 0;
         return;
@@ -10,7 +10,7 @@ void pay_cmd_tx_data_callback(uint8_t* data, uint8_t *len) {
     *len = 8;
 }
 
-void eps_cmd_tx_data_callback(uint8_t* data, uint8_t *len) {
+void eps_cmd_tx_callback(uint8_t* data, uint8_t *len) {
     if (queue_empty(&eps_tx_msg_queue)) {
         *len = 0;
         return;
@@ -20,7 +20,7 @@ void eps_cmd_tx_data_callback(uint8_t* data, uint8_t *len) {
     *len = 8;
 }
 
-void data_rx_callback(const uint8_t* data, uint8_t len) {
+void cmd_rx_callback(const uint8_t* data, uint8_t len) {
     if (len == 0) {
         return;
     }
@@ -37,7 +37,7 @@ mob_t pay_cmd_tx_mob = {
     .mob_type = TX_MOB,
     .id_tag = { OBC_PAY_CMD_TX_MOB_ID },
     .ctrl = default_tx_ctrl,
-    .tx_data_cb = pay_cmd_tx_data_callback
+    .tx_data_cb = pay_cmd_tx_callback
 };
 
 // CAN mob for sending commands to EPS
@@ -46,7 +46,7 @@ mob_t eps_cmd_tx_mob = {
     .mob_type = TX_MOB,
     .id_tag = { OBC_EPS_CMD_TX_MOB_ID },
     .ctrl = default_tx_ctrl,
-    .tx_data_cb = eps_cmd_tx_data_callback
+    .tx_data_cb = eps_cmd_tx_callback
 };
 
 // CAN mob for receiving data from any SSM
@@ -57,5 +57,5 @@ mob_t cmd_rx_mob = {
     .id_tag = { OBC_OBC_CMD_MOB_ID },
     .id_mask = { CAN_RX_MASK_ID },
     .ctrl = default_rx_ctrl,
-    .rx_cb = data_rx_callback
+    .rx_cb = cmd_rx_callback
 };

--- a/src/command_utilities.c
+++ b/src/command_utilities.c
@@ -91,7 +91,8 @@ void handle_trans_rx_dec_msg(void) {
         trans_rx_dec_avail = false;
         // Only accept 13 byte messages
         if (trans_rx_dec_len < 13) {
-            add_trans_tx_ack(0xFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x02);
+            // Don't know the opcode/args
+            add_trans_tx_ack(CMD_OPCODE_UNKNOWN, CMD_ARG_UNKNOWN, CMD_ARG_UNKNOWN, CMD_ACK_STATUS_INVALID_DEC_FMT);
             return;
         }
 
@@ -111,7 +112,7 @@ void handle_trans_rx_dec_msg(void) {
 
         cmd_t* cmd = cmd_opcode_to_cmd(opcode);
         if (cmd == &nop_cmd) {
-            add_trans_tx_ack(opcode, arg1, arg2, 0x03);
+            add_trans_tx_ack(opcode, arg1, arg2, CMD_ACK_STATUS_INVALID_OPCODE);
             return;
         }
 
@@ -120,13 +121,13 @@ void handle_trans_rx_dec_msg(void) {
             for (uint8_t i = 0; i < 4; i++) {
                 if (msg[9 + i] != correct_pwd[i]) {
                     // NACK
-                    add_trans_tx_ack(opcode, arg1, arg2, 0x04);
+                    add_trans_tx_ack(opcode, arg1, arg2, CMD_ACK_STATUS_INVALID_PWD);
                     return;
                 }
             }
         }
         
-        add_trans_tx_ack(opcode, arg1, arg2, 0x00);
+        add_trans_tx_ack(opcode, arg1, arg2, CMD_ACK_STATUS_OK);
         enqueue_cmd(cmd, arg1, arg2);
     }
 }
@@ -503,7 +504,7 @@ void cmd_timeout_timer_cb(void) {
 
     cmd_timeout_count_s += 1;
     if (cmd_timeout_count_s >= cmd_timeout_period_s) {
-        finish_current_cmd(CMD_STATUS_TIMED_OUT);
+        finish_current_cmd(CMD_RESP_STATUS_TIMED_OUT);
     }
 }
 

--- a/src/command_utilities.c
+++ b/src/command_utilities.c
@@ -129,6 +129,9 @@ void handle_trans_rx_dec_msg(void) {
         
         add_trans_tx_ack(opcode, arg1, arg2, CMD_ACK_STATUS_OK);
         enqueue_cmd(cmd, arg1, arg2);
+
+        // Restart the counter for not receiving communication from ground
+        restart_com_timeout();
     }
 }
 
@@ -294,10 +297,7 @@ void execute_next_cmd(void) {
     }
 
     print("Starting cmd\n");
-
-    // TODO - this should be moved to when receiving a transceiver packet instead
-    // Restart the counter for not receiving communication
-    restart_com_timeout();
+    
     // Start timeout timer at 0
     cmd_timeout_count_s = 0;
 

--- a/src/command_utilities.c
+++ b/src/command_utilities.c
@@ -340,7 +340,7 @@ void execute_next_cmd(void) {
     }
 
     // Log everything for the command (except the status byte)
-    populate_header(&cmd_log_header, cmd_log_mem_section->curr_block, 0xFF);
+    populate_header(&cmd_log_header, cmd_log_mem_section->curr_block, CMD_RESP_STATUS_UNKNOWN);
     write_mem_cmd_block(cmd_log_mem_section, cmd_log_mem_section->curr_block,
         &cmd_log_header,
         current_cmd->opcode, current_cmd_arg1, current_cmd_arg2);

--- a/src/command_utilities.c
+++ b/src/command_utilities.c
@@ -1,5 +1,8 @@
 #include "command_utilities.h"
 
+// Uncomment for extra debugging prints
+// #define COMMAND_UTILITIES_DEBUG
+
 // If you get an error here because `security.h` is not found, copy the dummy
 // `security.h` file from https://github.com/HeronMkII/templates to your `src`
 // folder and try again
@@ -229,7 +232,9 @@ something goes wrong.
 cmd - Command to enqueue
 */
 void enqueue_cmd(cmd_t* cmd, uint32_t arg1, uint32_t arg2) {
+#ifdef COMMAND_UTILITIES_DEBUG
     print("enqueue_cmd: opcode = 0x%x, arg1 = 0x%lx, arg2 = 0x%lx\n", cmd->opcode, arg1, arg2);
+#endif
 
     // Enqueue the command as an 8-byte array
     uint8_t opcode_data[8] = {0};
@@ -287,8 +292,10 @@ void dequeue_cmd(cmd_t** cmd, uint32_t* arg1, uint32_t* arg2) {
             (((uint32_t) args_data[7]));
     }
 
+#ifdef COMMAND_UTILITIES_DEBUG
     print("dequeue_cmd: opcode = 0x%x, arg1 = 0x%lx, arg2 = 0x%lx\n", (*cmd)->opcode,
         *arg1, *arg2);
+#endif
 }
 
 // If the command queue is not empty, dequeues the next command and executes it
@@ -317,8 +324,10 @@ void execute_next_cmd(void) {
             current_cmd->opcode, current_cmd_arg1, current_cmd_arg2);
     }
 
+#ifdef COMMAND_UTILITIES_DEBUG
     print("Starting cmd\n");
-    
+#endif
+
     // Start timeout timer at 0
     cmd_timeout_count_s = 0;
 
@@ -363,7 +372,10 @@ void finish_current_cmd(uint8_t status) {
         current_cmd_arg2 = 0;
         cmd_timeout_count_s = 0;
     }
+
+#ifdef COMMAND_UTILITIES_DEBUG
     print("Finished cmd\n");
+#endif
 }
 
 
@@ -478,7 +490,9 @@ void auto_data_col_timer_cb(void) {
         obc_hk_auto_data_col.count += 1;
 
         if (obc_hk_auto_data_col.count >= obc_hk_auto_data_col.period) {
+#ifdef COMMAND_UTILITIES_DEBUG
             print("Auto OBC_HK\n");
+#endif
             obc_hk_auto_data_col.count = 0;
             enqueue_cmd(&col_data_block_cmd, CMD_OBC_HK, 1);    // auto
         }
@@ -488,7 +502,9 @@ void auto_data_col_timer_cb(void) {
         eps_hk_auto_data_col.count += 1;
 
         if (eps_hk_auto_data_col.count >= eps_hk_auto_data_col.period) {
+#ifdef COMMAND_UTILITIES_DEBUG
             print("Auto EPS_HK\n");
+#endif
             eps_hk_auto_data_col.count = 0;
             enqueue_cmd(&col_data_block_cmd, CMD_EPS_HK, 1);    // auto
         }
@@ -498,7 +514,9 @@ void auto_data_col_timer_cb(void) {
         pay_hk_auto_data_col.count += 1;
 
         if (pay_hk_auto_data_col.count >= pay_hk_auto_data_col.period) {
+#ifdef COMMAND_UTILITIES_DEBUG
             print("Auto PAY_HK\n");
+#endif
             pay_hk_auto_data_col.count = 0;
             enqueue_cmd(&col_data_block_cmd, CMD_PAY_HK, 1);    // auto
         }
@@ -508,7 +526,9 @@ void auto_data_col_timer_cb(void) {
         pay_opt_auto_data_col.count += 1;
 
         if (pay_opt_auto_data_col.count >= pay_opt_auto_data_col.period) {
+#ifdef COMMAND_UTILITIES_DEBUG
             print("Auto PAY_OPT\n");
+#endif
             pay_opt_auto_data_col.count = 0;
             enqueue_cmd(&col_data_block_cmd, CMD_PAY_OPT, 1);   // auto
         }

--- a/src/command_utilities.c
+++ b/src/command_utilities.c
@@ -140,8 +140,7 @@ void process_trans_tx_ack(void) {
         trans_tx_ack_avail = false;
 
         // Can't use the standard trans_tx_dec functions because they use the current_cmd variables
-        // TODO - better way?
-        trans_tx_dec_msg[0] = trans_tx_ack_opcode | (0x1 << 7);
+        trans_tx_dec_msg[0] = trans_tx_ack_opcode | CMD_ACK_OPCODE_MASK;
         trans_tx_dec_msg[1] = (trans_tx_ack_arg1 >> 24) & 0xFF;
         trans_tx_dec_msg[2] = (trans_tx_ack_arg1 >> 16) & 0xFF;
         trans_tx_dec_msg[3] = (trans_tx_ack_arg1 >> 8) & 0xFF;

--- a/src/command_utilities.h
+++ b/src/command_utilities.h
@@ -70,6 +70,9 @@ typedef struct {
 #define CMD_RESET_SUBSYS                0x43
 #define CMD_SET_INDEF_LPM_ENABLE        0x44
 
+// Mask to set MSB on opcode byte for ACK packets
+#define CMD_ACK_OPCODE_MASK             (0x1 << 7)
+
 // ACK status bytes
 #define CMD_ACK_STATUS_OK               0x00
 #define CMD_ACK_STATUS_INVALID_PKT      0x01

--- a/src/command_utilities.h
+++ b/src/command_utilities.h
@@ -70,11 +70,22 @@ typedef struct {
 #define CMD_RESET_SUBSYS                0x43
 #define CMD_SET_INDEF_LPM_ENABLE        0x44
 
-// Response/command log stataus bytes
-#define CMD_STATUS_OK           0x00
-#define CMD_STATUS_INVALID_ARGS 0x01
-#define CMD_STATUS_TIMED_OUT    0x02
-#define CMD_STATUS_UNKNOWN      0xFF
+// ACK status bytes
+#define CMD_ACK_STATUS_OK               0x00
+#define CMD_ACK_STATUS_INVALID_PKT      0x01
+#define CMD_ACK_STATUS_INVALID_DEC_FMT  0x02
+#define CMD_ACK_STATUS_INVALID_OPCODE   0x03
+#define CMD_ACK_STATUS_INVALID_PWD      0x04
+
+// Response/command log status bytes
+#define CMD_RESP_STATUS_OK              0x00
+#define CMD_RESP_STATUS_INVALID_ARGS    0x01
+#define CMD_RESP_STATUS_TIMED_OUT       0x02
+#define CMD_RESP_STATUS_UNKNOWN         0xFF
+
+// For unsuccessful ACKs where opcode/args are unknown
+#define CMD_OPCODE_UNKNOWN              0xFF
+#define CMD_ARG_UNKNOWN                 0xFFFFFFFF
 
 // TODO - change value?
 #define CMD_TIMEOUT_DEF_PERIOD_S    30

--- a/src/command_utilities.h
+++ b/src/command_utilities.h
@@ -165,6 +165,9 @@ extern volatile auto_data_col_t* all_auto_data_cols[];
 extern rtc_date_t restart_date;
 extern rtc_time_t restart_time;
 
+extern bool print_cmds;
+extern bool print_trans_tx_acks;
+
 
 void handle_trans_rx_dec_msg(void);
 void process_trans_tx_ack(void);

--- a/src/commands.c
+++ b/src/commands.c
@@ -660,9 +660,15 @@ void col_data_block_fn(void) {
                 ((uint32_t) restart_time.mm << 8) |
                 ((uint32_t) restart_time.ss << 0);
 
-            // Write data to the section and increment the block number
-            write_mem_data_block(&obc_hk_mem_section, obc_hk_mem_section.curr_block,
-                &obc_hk_header, obc_hk_fields);
+            // Write header (except status)
+            write_mem_header_main(&obc_hk_mem_section, obc_hk_mem_section.curr_block, &obc_hk_header);
+            // Write data fields
+            for (uint8_t i = 0; i < obc_hk_mem_section.fields_per_block; i++) {
+                write_mem_field(&obc_hk_mem_section, obc_hk_mem_section.curr_block, i, obc_hk_fields[i]);
+                // i is field number; fields[i] corresponds to associated field data
+            }
+
+            // Increment the block number
             inc_and_prepare_mem_section_curr_block(&obc_hk_mem_section);
 
             // Only send back a transceiver packet if the command was sent from

--- a/src/commands.c
+++ b/src/commands.c
@@ -637,13 +637,12 @@ void erase_all_mem_fn(void) {
 }
 
 // Starts requesting block data (field 0)
-// TODO - don't write success byte later, write at end in CAN RX processing
 void col_data_block_fn(void) {
     switch (current_cmd_arg1) {
         case CMD_OBC_HK:
             print("Start OBC_HK\n");
 
-            populate_header(&obc_hk_header, obc_hk_mem_section.curr_block, 0x00);
+            populate_header(&obc_hk_header, obc_hk_mem_section.curr_block, CMD_RESP_STATUS_OK);
             obc_hk_fields[CAN_OBC_HK_UPTIME] = uptime_s;
             obc_hk_fields[CAN_OBC_HK_RESTART_COUNT] = restart_count;
             obc_hk_fields[CAN_OBC_HK_RESTART_REASON] = restart_reason;
@@ -682,19 +681,28 @@ void col_data_block_fn(void) {
 
         case CMD_EPS_HK:
             print("Start EPS_HK\n");
-            populate_header(&eps_hk_header, eps_hk_mem_section.curr_block, 0x00);
+            populate_header(&eps_hk_header, eps_hk_mem_section.curr_block, CMD_RESP_STATUS_UNKNOWN);
+            write_mem_header_main(&eps_hk_mem_section, eps_hk_mem_section.curr_block, &eps_hk_header);
+            // This increment invalidates the current block number for the
+            // memory section struct for the current command, so the command
+            // will need to fetch the block number from the header
+            inc_and_prepare_mem_section_curr_block(&eps_hk_mem_section);
             enqueue_eps_tx_msg(CAN_EPS_HK, 0, 0);
             break;
 
         case CMD_PAY_HK:
             print ("Start PAY_HK\n");
-            populate_header(&pay_hk_header, pay_hk_mem_section.curr_block, 0x00);
+            populate_header(&pay_hk_header, pay_hk_mem_section.curr_block, CMD_RESP_STATUS_UNKNOWN);
+            write_mem_header_main(&pay_hk_mem_section, pay_hk_mem_section.curr_block, &pay_hk_header);
+            inc_and_prepare_mem_section_curr_block(&pay_hk_mem_section);
             enqueue_pay_tx_msg(CAN_PAY_HK, 0, 0);
             break;
 
         case CMD_PAY_OPT:
             print ("Start PAY_OPT\n");
-            populate_header(&pay_opt_header, pay_opt_mem_section.curr_block, 0x00);
+            populate_header(&pay_opt_header, pay_opt_mem_section.curr_block, CMD_RESP_STATUS_UNKNOWN);
+            write_mem_header_main(&pay_opt_mem_section, pay_opt_mem_section.curr_block, &pay_opt_header);
+            inc_and_prepare_mem_section_curr_block(&pay_opt_mem_section);
             enqueue_pay_tx_msg(CAN_PAY_OPT, 0, 0);
             break;
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -647,7 +647,7 @@ void col_data_block_fn(void) {
             print("Start OBC_HK\n");
 #endif
 
-            populate_header(&obc_hk_header, obc_hk_mem_section.curr_block, CMD_RESP_STATUS_OK);
+            populate_header(&obc_hk_header, obc_hk_mem_section.curr_block, CMD_RESP_STATUS_UNKNOWN);
             obc_hk_fields[CAN_OBC_HK_UPTIME] = uptime_s;
             obc_hk_fields[CAN_OBC_HK_RESTART_COUNT] = restart_count;
             obc_hk_fields[CAN_OBC_HK_RESTART_REASON] = restart_reason;

--- a/src/commands.c
+++ b/src/commands.c
@@ -262,8 +262,8 @@ void nop_fn(void) {
 }
 
 void ping_obc_fn(void) {
-    add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-    finish_current_cmd(CMD_STATUS_OK);
+    add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void get_rtc_fn(void) {
@@ -271,7 +271,7 @@ void get_rtc_fn(void) {
     rtc_time_t time = read_rtc_time();
 
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        start_trans_tx_dec_msg(CMD_STATUS_OK);
+        start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
         append_to_trans_tx_dec_msg(date.yy);
         append_to_trans_tx_dec_msg(date.mm);
         append_to_trans_tx_dec_msg(date.dd);
@@ -280,7 +280,7 @@ void get_rtc_fn(void) {
         append_to_trans_tx_dec_msg(time.ss);
         finish_trans_tx_dec_msg();
     }
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void set_rtc_fn(void) {
@@ -298,29 +298,29 @@ void set_rtc_fn(void) {
     set_rtc_date(date);
     set_rtc_time(time);
 
-    add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-    finish_current_cmd(CMD_STATUS_OK);
+    add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void read_obc_eeprom_fn(void) {
     uint32_t data = read_eeprom((uint16_t) current_cmd_arg2);
 
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        start_trans_tx_dec_msg(CMD_STATUS_OK);
+        start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
         append_to_trans_tx_dec_msg((data >> 24) & 0xFF);
         append_to_trans_tx_dec_msg((data >> 16) & 0xFF);
         append_to_trans_tx_dec_msg((data >> 8) & 0xFF);
         append_to_trans_tx_dec_msg(data & 0xFF);
         finish_trans_tx_dec_msg();
     }
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void erase_obc_eeprom_fn(void) {
     write_eeprom((uint16_t) current_cmd_arg2, EEPROM_DEF_DWORD);
     
-    add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-    finish_current_cmd(CMD_STATUS_OK);
+    add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void read_obc_ram_byte_fn(void) {
@@ -335,11 +335,11 @@ void read_obc_ram_byte_fn(void) {
     uint8_t data = *pointer;
 
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        start_trans_tx_dec_msg(CMD_STATUS_OK);
+        start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
         append_to_trans_tx_dec_msg(data);
         finish_trans_tx_dec_msg();
     }
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void set_beacon_inhibit_enable_fn(void) {
@@ -358,12 +358,12 @@ void set_beacon_inhibit_enable_fn(void) {
             beacon_inhibit_count_s = 0;
         }
     } else {
-        add_def_trans_tx_dec_msg(CMD_STATUS_INVALID_ARGS);
-        finish_current_cmd(CMD_STATUS_INVALID_ARGS);
+        add_def_trans_tx_dec_msg(CMD_RESP_STATUS_INVALID_ARGS);
+        finish_current_cmd(CMD_RESP_STATUS_INVALID_ARGS);
     }
     
-    add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-    finish_current_cmd(CMD_STATUS_OK);
+    add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void send_eps_can_msg_fn(void) {
@@ -393,26 +393,26 @@ void reset_subsys_fn(void) {
         reset_self_mcu(UPTIME_RESTART_REASON_RESET_CMD);
         // Program should stop here and restart from the beginning
 
-        add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-        finish_current_cmd(CMD_STATUS_OK);
+        add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+        finish_current_cmd(CMD_RESP_STATUS_OK);
     }
     // PAY/EPS will not respond so don't expect a CAN message back
     // Just finish the current command
     else if (current_cmd_arg1 == CMD_EPS) {
         enqueue_eps_tx_msg(CAN_EPS_CTRL, CAN_EPS_CTRL_RESET, 0);
 
-        add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-        finish_current_cmd(CMD_STATUS_OK);
+        add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+        finish_current_cmd(CMD_RESP_STATUS_OK);
     }
     else if (current_cmd_arg1 == CMD_PAY) {
         enqueue_pay_tx_msg(CAN_PAY_CTRL, CAN_PAY_CTRL_RESET, 0);
 
-        add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-        finish_current_cmd(CMD_STATUS_OK);
+        add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+        finish_current_cmd(CMD_RESP_STATUS_OK);
     }
     else {
-        add_def_trans_tx_dec_msg(CMD_STATUS_INVALID_ARGS);
-        finish_current_cmd(CMD_STATUS_INVALID_ARGS);
+        add_def_trans_tx_dec_msg(CMD_RESP_STATUS_INVALID_ARGS);
+        finish_current_cmd(CMD_RESP_STATUS_INVALID_ARGS);
     }
 }
 
@@ -421,8 +421,8 @@ void set_indef_lpm_enable_fn(void) {
     enqueue_eps_tx_msg(CAN_EPS_CTRL, CAN_EPS_CTRL_ENABLE_INDEF_LPM, 0);
     enqueue_pay_tx_msg(CAN_PAY_CTRL, CAN_PAY_CTRL_ENABLE_INDEF_LPM, 0);
 
-    add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-    finish_current_cmd(CMD_STATUS_OK);
+    add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void read_rec_status_info_fn(void) {    
@@ -438,7 +438,7 @@ void read_rec_status_info_fn(void) {
     read_mem_data_block(&pay_hk_mem_section, pay_block, &pay_hk_header, pay_hk_fields);
 
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        start_trans_tx_dec_msg(CMD_STATUS_OK);
+        start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
 
         for (uint8_t i = CAN_OBC_HK_UPTIME; i <= CAN_OBC_HK_RESTART_TIME; i++) {
             append_to_trans_tx_dec_msg((obc_hk_fields[i] >> 16) & 0xFF);
@@ -459,12 +459,12 @@ void read_rec_status_info_fn(void) {
         finish_trans_tx_dec_msg();
     }
 
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void read_data_block_fn(void) {
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        start_trans_tx_dec_msg(CMD_STATUS_OK);
+        start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
 
         switch (current_cmd_arg1) {
             case CMD_OBC_HK:
@@ -496,8 +496,8 @@ void read_data_block_fn(void) {
                 break;
 
             default:
-                add_def_trans_tx_dec_msg(CMD_STATUS_INVALID_ARGS);
-                finish_current_cmd(CMD_STATUS_INVALID_ARGS);
+                add_def_trans_tx_dec_msg(CMD_RESP_STATUS_INVALID_ARGS);
+                finish_current_cmd(CMD_RESP_STATUS_INVALID_ARGS);
                 // TODO - will it properly terminate the trans msg?
                 return;
         }
@@ -505,12 +505,12 @@ void read_data_block_fn(void) {
         finish_trans_tx_dec_msg();
     }
 
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void read_rec_loc_data_block_fn(void) {
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        start_trans_tx_dec_msg(CMD_STATUS_OK);
+        start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
 
         switch (current_cmd_arg1) {
             case CMD_OBC_HK:
@@ -530,26 +530,26 @@ void read_rec_loc_data_block_fn(void) {
                 append_fields_to_tx_msg(pay_opt_fields, CAN_PAY_OPT_FIELD_COUNT);
                 break;
             default:
-                add_def_trans_tx_dec_msg(CMD_STATUS_INVALID_ARGS);
-                finish_current_cmd(CMD_STATUS_INVALID_ARGS);
+                add_def_trans_tx_dec_msg(CMD_RESP_STATUS_INVALID_ARGS);
+                finish_current_cmd(CMD_RESP_STATUS_INVALID_ARGS);
                 return;
         }
 
         finish_trans_tx_dec_msg();
     }
 
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void read_prim_cmd_blocks_fn(void) {
     if (current_cmd_arg2 > 5) {
-        add_def_trans_tx_dec_msg(CMD_STATUS_INVALID_ARGS);
-        finish_current_cmd(CMD_STATUS_INVALID_ARGS);
+        add_def_trans_tx_dec_msg(CMD_RESP_STATUS_INVALID_ARGS);
+        finish_current_cmd(CMD_RESP_STATUS_INVALID_ARGS);
         return;
     }
 
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        start_trans_tx_dec_msg(CMD_STATUS_OK);
+        start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
 
         for (uint32_t block_num = current_cmd_arg1;
             block_num < current_cmd_arg1 + current_cmd_arg2;
@@ -577,19 +577,19 @@ void read_prim_cmd_blocks_fn(void) {
         finish_trans_tx_dec_msg();
     }
 
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void read_sec_cmd_blocks_fn(void) {
     // TODO - refactor common with primary command?
     if (current_cmd_arg2 > 5) {
-        add_def_trans_tx_dec_msg(CMD_STATUS_INVALID_ARGS);
-        finish_current_cmd(CMD_STATUS_INVALID_ARGS);
+        add_def_trans_tx_dec_msg(CMD_RESP_STATUS_INVALID_ARGS);
+        finish_current_cmd(CMD_RESP_STATUS_INVALID_ARGS);
         return;
     }
 
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        start_trans_tx_dec_msg(CMD_STATUS_OK);
+        start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
 
         for (uint32_t block_num = current_cmd_arg1;
             block_num < current_cmd_arg1 + current_cmd_arg2;
@@ -617,14 +617,14 @@ void read_sec_cmd_blocks_fn(void) {
         finish_trans_tx_dec_msg();
     }
 
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void read_raw_mem_bytes_fn(void) {
     // Enforce max number of bytes
     if (current_cmd_arg2 > CMD_READ_MEM_MAX_COUNT) {
-        add_def_trans_tx_dec_msg(CMD_STATUS_INVALID_ARGS);
-        finish_current_cmd(CMD_STATUS_INVALID_ARGS);
+        add_def_trans_tx_dec_msg(CMD_RESP_STATUS_INVALID_ARGS);
+        finish_current_cmd(CMD_RESP_STATUS_INVALID_ARGS);
         return;
     }
 
@@ -632,14 +632,14 @@ void read_raw_mem_bytes_fn(void) {
     read_mem_bytes(current_cmd_arg1, data, (uint8_t) current_cmd_arg2);
 
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        start_trans_tx_dec_msg(CMD_STATUS_OK);
+        start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
         for (uint8_t i = 0; i < (uint8_t) current_cmd_arg2; i++) {
             append_to_trans_tx_dec_msg(data[i]);
         }
         finish_trans_tx_dec_msg();
     }
 
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void erase_mem_phy_sector_fn(void) {
@@ -648,24 +648,24 @@ void erase_mem_phy_sector_fn(void) {
     // Only send a transceiver packet if the erase was initiated by the ground
     // station (argument 2 = 0)
     if (current_cmd_arg2 == 0) {
-        add_def_trans_tx_dec_msg(CMD_STATUS_OK);
+        add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
     }
 
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void erase_mem_phy_block_fn(void) {
     erase_mem_block(current_cmd_arg1);
 
-    add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-    finish_current_cmd(CMD_STATUS_OK);
+    add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void erase_all_mem_fn(void) {
     erase_mem();
 
-    add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-    finish_current_cmd(CMD_STATUS_OK);
+    add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 // Starts requesting block data (field 0)
@@ -697,7 +697,7 @@ void col_data_block_fn(void) {
             // ground (arg2 = 0)
             if (current_cmd_arg2 == 0) {
                 ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-                    start_trans_tx_dec_msg(CMD_STATUS_OK);
+                    start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
                     append_to_trans_tx_dec_msg((obc_hk_mem_section.curr_block >> 24) & 0xFF);
                     append_to_trans_tx_dec_msg((obc_hk_mem_section.curr_block >> 16) & 0xFF);
                     append_to_trans_tx_dec_msg((obc_hk_mem_section.curr_block >> 8) & 0xFF);
@@ -707,7 +707,7 @@ void col_data_block_fn(void) {
             }
 
             print("Done OBC_HK\n");
-            finish_current_cmd(CMD_STATUS_OK);
+            finish_current_cmd(CMD_RESP_STATUS_OK);
             
             // Don't use CAN
             return;
@@ -731,8 +731,8 @@ void col_data_block_fn(void) {
             break;
 
         default:
-            add_def_trans_tx_dec_msg(CMD_STATUS_INVALID_ARGS);
-            finish_current_cmd(CMD_STATUS_INVALID_ARGS);
+            add_def_trans_tx_dec_msg(CMD_RESP_STATUS_INVALID_ARGS);
+            finish_current_cmd(CMD_RESP_STATUS_INVALID_ARGS);
             return;
     }
 
@@ -741,7 +741,7 @@ void col_data_block_fn(void) {
 
 void get_cur_block_nums_fn(void) {
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        start_trans_tx_dec_msg(CMD_STATUS_OK);
+        start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
 
         for (uint8_t i = 0; i < MEM_NUM_SECTIONS; i++) {
             append_to_trans_tx_dec_msg((all_mem_sections[i]->curr_block >> 24) & 0xFF);
@@ -753,7 +753,7 @@ void get_cur_block_nums_fn(void) {
         finish_trans_tx_dec_msg();
     }
 
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 // TODO - OBC needs to erase memory sectors automatically when resetting current
@@ -779,18 +779,18 @@ void set_cur_block_num_fn(void) {
             prepare_mem_section_curr_block(&sec_cmd_log_mem_section, current_cmd_arg2);
             break;
         default:
-            add_def_trans_tx_dec_msg(CMD_STATUS_INVALID_ARGS);
-            finish_current_cmd(CMD_STATUS_INVALID_ARGS);
+            add_def_trans_tx_dec_msg(CMD_RESP_STATUS_INVALID_ARGS);
+            finish_current_cmd(CMD_RESP_STATUS_INVALID_ARGS);
             return;
     }
 
-    add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-    finish_current_cmd(CMD_STATUS_OK);
+    add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void get_mem_sec_addrs_fn(void) {
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        start_trans_tx_dec_msg(CMD_STATUS_OK);
+        start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
 
         for (uint8_t i = 0; i < MEM_NUM_SECTIONS; i++) {
             append_to_trans_tx_dec_msg((all_mem_sections[i]->start_addr >> 24) & 0xFF);
@@ -806,7 +806,7 @@ void get_mem_sec_addrs_fn(void) {
         finish_trans_tx_dec_msg();
     }
 
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void set_mem_sec_start_addr_fn(void) {
@@ -830,13 +830,13 @@ void set_mem_sec_start_addr_fn(void) {
             sec_cmd_log_mem_section.start_addr = current_cmd_arg2;
             break;
         default:
-            add_def_trans_tx_dec_msg(CMD_STATUS_INVALID_ARGS);
-            finish_current_cmd(CMD_STATUS_INVALID_ARGS);
+            add_def_trans_tx_dec_msg(CMD_RESP_STATUS_INVALID_ARGS);
+            finish_current_cmd(CMD_RESP_STATUS_INVALID_ARGS);
             return;
     }
 
-    add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-    finish_current_cmd(CMD_STATUS_OK);
+    add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void set_mem_sec_end_addr_fn(void) {
@@ -860,18 +860,18 @@ void set_mem_sec_end_addr_fn(void) {
             sec_cmd_log_mem_section.end_addr = current_cmd_arg2;
             break;
         default:
-            add_def_trans_tx_dec_msg(CMD_STATUS_INVALID_ARGS);
-            finish_current_cmd(CMD_STATUS_INVALID_ARGS);
+            add_def_trans_tx_dec_msg(CMD_RESP_STATUS_INVALID_ARGS);
+            finish_current_cmd(CMD_RESP_STATUS_INVALID_ARGS);
             return;
     }
 
-    add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-    finish_current_cmd(CMD_STATUS_OK);
+    add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void get_auto_data_col_settings_fn(void) {
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        start_trans_tx_dec_msg(CMD_STATUS_OK);
+        start_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
 
         for (uint8_t i = 0; i < NUM_AUTO_DATA_COL_SECTIONS; i++) {
             append_to_trans_tx_dec_msg((uint8_t) all_auto_data_cols[i]->enabled);
@@ -888,7 +888,7 @@ void get_auto_data_col_settings_fn(void) {
         finish_trans_tx_dec_msg();
     }
 
-    finish_current_cmd(CMD_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void set_auto_data_col_enable_fn(void) {
@@ -910,13 +910,13 @@ void set_auto_data_col_enable_fn(void) {
             write_eeprom(PAY_OPT_AUTO_DATA_COL_ENABLED_EEPROM_ADDR, pay_opt_auto_data_col.enabled);
             break;
         default:
-            add_def_trans_tx_dec_msg(CMD_STATUS_INVALID_ARGS);
-            finish_current_cmd(CMD_STATUS_INVALID_ARGS);
+            add_def_trans_tx_dec_msg(CMD_RESP_STATUS_INVALID_ARGS);
+            finish_current_cmd(CMD_RESP_STATUS_INVALID_ARGS);
             return;
     }
 
-    add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-    finish_current_cmd(CMD_STATUS_OK);
+    add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void set_auto_data_col_period_fn(void) {
@@ -938,13 +938,13 @@ void set_auto_data_col_period_fn(void) {
             write_eeprom(PAY_OPT_AUTO_DATA_COL_PERIOD_EEPROM_ADDR, pay_opt_auto_data_col.period);
             break;
         default:
-            add_def_trans_tx_dec_msg(CMD_STATUS_INVALID_ARGS);
-            finish_current_cmd(CMD_STATUS_INVALID_ARGS);
+            add_def_trans_tx_dec_msg(CMD_RESP_STATUS_INVALID_ARGS);
+            finish_current_cmd(CMD_RESP_STATUS_INVALID_ARGS);
             return;
     }
 
-    add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-    finish_current_cmd(CMD_STATUS_OK);
+    add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }
 
 void resync_auto_data_col_timers_fn(void) {
@@ -955,6 +955,6 @@ void resync_auto_data_col_timers_fn(void) {
         pay_opt_auto_data_col.count = 0;
     }
 
-    add_def_trans_tx_dec_msg(CMD_STATUS_OK);
-    finish_current_cmd(CMD_STATUS_OK);
+    add_def_trans_tx_dec_msg(CMD_RESP_STATUS_OK);
+    finish_current_cmd(CMD_RESP_STATUS_OK);
 }

--- a/src/commands.c
+++ b/src/commands.c
@@ -1,5 +1,8 @@
 #include "commands.h"
 
+// Uncomment for extra debugging prints
+// #define COMMANDS_DEBUG
+
 
 void nop_fn(void);
 
@@ -640,7 +643,9 @@ void erase_all_mem_fn(void) {
 void col_data_block_fn(void) {
     switch (current_cmd_arg1) {
         case CMD_OBC_HK:
+#ifdef COMMANDS_DEBUG
             print("Start OBC_HK\n");
+#endif
 
             populate_header(&obc_hk_header, obc_hk_mem_section.curr_block, CMD_RESP_STATUS_OK);
             obc_hk_fields[CAN_OBC_HK_UPTIME] = uptime_s;
@@ -672,15 +677,18 @@ void col_data_block_fn(void) {
                     finish_trans_tx_dec_msg();
                 }
             }
-
+#ifdef COMMANDS_DEBUG
             print("Done OBC_HK\n");
+#endif
             finish_current_cmd(CMD_RESP_STATUS_OK);
             
             // Don't use CAN
             return;
 
         case CMD_EPS_HK:
+#ifdef COMMANDS_DEBUG
             print("Start EPS_HK\n");
+#endif
             populate_header(&eps_hk_header, eps_hk_mem_section.curr_block, CMD_RESP_STATUS_UNKNOWN);
             write_mem_header_main(&eps_hk_mem_section, eps_hk_mem_section.curr_block, &eps_hk_header);
             // This increment invalidates the current block number for the
@@ -691,7 +699,9 @@ void col_data_block_fn(void) {
             break;
 
         case CMD_PAY_HK:
+#ifdef COMMANDS_DEBUG
             print ("Start PAY_HK\n");
+#endif
             populate_header(&pay_hk_header, pay_hk_mem_section.curr_block, CMD_RESP_STATUS_UNKNOWN);
             write_mem_header_main(&pay_hk_mem_section, pay_hk_mem_section.curr_block, &pay_hk_header);
             inc_and_prepare_mem_section_curr_block(&pay_hk_mem_section);
@@ -699,7 +709,9 @@ void col_data_block_fn(void) {
             break;
 
         case CMD_PAY_OPT:
+#ifdef COMMANDS_DEBUG
             print ("Start PAY_OPT\n");
+#endif
             populate_header(&pay_opt_header, pay_opt_mem_section.curr_block, CMD_RESP_STATUS_UNKNOWN);
             write_mem_header_main(&pay_opt_mem_section, pay_opt_mem_section.curr_block, &pay_opt_header);
             inc_and_prepare_mem_section_curr_block(&pay_opt_mem_section);

--- a/src/mem.c
+++ b/src/mem.c
@@ -195,11 +195,11 @@ uint8_t write_mem_cmd_block(mem_section_t* section, uint32_t block_num, mem_head
      * the header, 1 byte for command type, 4 bytes for arg 1, and 4 bytes for arg 2.
      * This format differs from the rest of the memory sections, which has standardized 3 bytes/field and multiple
      * fields forming a block
+     * This does NOT write the status byte (should be done separately later)
      * Returns a 1 if write was successful, 0 if not
      */
 
     write_mem_header_main(section, block_num, header);
-    write_mem_header_status(section, block_num, header->status);
 
     // calculate the address based on block number. This is the offset address from the start of the section
     uint32_t start_address = mem_cmd_section_addr(section, block_num);

--- a/src/mem.c
+++ b/src/mem.c
@@ -173,24 +173,6 @@ void set_mem_section_curr_block(mem_section_t* section, uint32_t curr_block) {
     write_mem_section_eeprom(section);
 }
 
-
-void write_mem_data_block(mem_section_t* section, uint32_t block_num,
-    mem_header_t* header, uint32_t* fields) {
-
-    // print("%s: ", __FUNCTION__);
-    // print("start_addr = 0x%.8lX, block_num = %lu\n", section->start_addr,
-    //     block_num);
-
-    // Write header
-    write_mem_header_main(section, block_num, header);
-    write_mem_header_status(section, block_num, header->status);
-    // Write data fields
-    for (uint8_t i = 0; i < section->fields_per_block; i++) {
-        write_mem_field(section, block_num, i, fields[i]);
-        // i is field number; fields[i] corresponds to associated field data
-    }
-}
-
 void read_mem_data_block(mem_section_t* section, uint32_t block_num,
     mem_header_t* header, uint32_t* fields) {
 

--- a/src/mem.h
+++ b/src/mem.h
@@ -134,8 +134,6 @@ void read_all_mem_sections_eeprom(void);
 void set_mem_section_curr_block(mem_section_t* section, uint32_t curr_block);
 
 // High-level operations - blocks
-void write_mem_data_block(mem_section_t* section, uint32_t block_num,
-    mem_header_t* header, uint32_t* fields);
 void read_mem_data_block(mem_section_t* section, uint32_t block_num,
     mem_header_t* header, uint32_t* fields);
 

--- a/src/mem.h
+++ b/src/mem.h
@@ -47,20 +47,22 @@
 #define MEM_BPL     7
 
 // Chips are numbered 0-2
-#define MEM_NUM_CHIPS           3
+#define MEM_NUM_CHIPS               3
 // The number of bits used to address all bytes in one chip
 // Because one chip is 2MB and each address is for one byte
-#define MEM_CHIP_ADDR_WIDTH     21
+#define MEM_CHIP_ADDR_WIDTH         21
 // Number of sections in memory layout
-#define MEM_NUM_SECTIONS        6
+#define MEM_NUM_SECTIONS            6
 // Number of bytes in a header
-#define MEM_BYTES_PER_HEADER    10
+#define MEM_BYTES_PER_HEADER        10
+// Location of status byte in header
+#define MEM_STATUS_HEADER_OFFSET    (MEM_BYTES_PER_HEADER - 1)
 // Number of bytes in one field (one measurement)
-#define MEM_BYTES_PER_FIELD     3
+#define MEM_BYTES_PER_FIELD         3
 // Number of bytes in one command log
-#define MEM_BYTES_PER_CMD       9
+#define MEM_BYTES_PER_CMD           9
 // Number of bytes per memory sector
-#define MEM_BYTES_PER_SECTOR    4096
+#define MEM_BYTES_PER_SECTOR        4096
 
 #define MEM_OBC_HK_START_ADDR       0x000000UL
 #define MEM_OBC_HK_END_ADDR         0x0FFFFFUL
@@ -82,9 +84,6 @@
 #define MEM_PAY_OPT_CURR_BLOCK_EEPROM_ADDR      0x170
 #define MEM_PRIM_CMD_LOG_CURR_BLOCK_EEPROM_ADDR 0x180
 #define MEM_SEC_CMD_LOG_CURR_BLOCK_EEPROM_ADDR  0x190
-
-// Location of status byte in header
-#define MEM_STATUS_HEADER_OFFSET   9
 
 
 // Sections in memory
@@ -146,7 +145,7 @@ void read_mem_cmd_block(mem_section_t* section, uint32_t block_num, mem_header_t
     uint8_t* cmd_num, uint32_t* arg1, uint32_t* arg2);
 
 // High-level operations - headers and fields
-void write_mem_header(mem_section_t* section, uint32_t block_num,
+void write_mem_header_main(mem_section_t* section, uint32_t block_num,
     mem_header_t* header);
 void write_mem_header_status(mem_section_t* section, uint32_t block_num,
     uint8_t status);

--- a/src/transceiver.c
+++ b/src/transceiver.c
@@ -53,6 +53,9 @@ In a raw hexdump of bytes, this is:
 
 #include "transceiver.h"
 
+// Uncomment for extra debugging prints
+#define TRANSCEIVER_DEBUG
+
 /*
 All buffers have the following format:
 [...] - characters in buffer (NO '\0' OR '\r' TERMINATION)
@@ -127,10 +130,11 @@ void trans_uptime_cb(void) {
         uptime_s - trans_rx_prev_uptime_s >= TRANS_RX_BUF_TIMEOUT &&
         get_uart_rx_buf_count() > 0) {
 
+#ifdef TRANSCEIVER_DEBUG
         print("UART RX buf (%u bytes): ", get_uart_rx_buf_count());
         print_bytes((uint8_t*) uart_rx_buf, get_uart_rx_buf_count());
-        clear_uart_rx_buf();
-        print("\nTimed out, cleared UART RX buf\n");
+        print("\nTimed out, clearing UART RX buf\n");
+#endif
 
         // Only send an ACK if we received more than 1 byte from a packet
         // i.e. ignore 1-byte ground station packets that are used to improve
@@ -139,6 +143,9 @@ void trans_uptime_cb(void) {
         if (get_uart_rx_buf_count() > 1) {
             add_trans_tx_ack(CMD_OPCODE_UNKNOWN, CMD_ARG_UNKNOWN, CMD_ARG_UNKNOWN, CMD_ACK_STATUS_INVALID_PKT);
         }
+
+        // Clearing buffer must happen after checking length
+        clear_uart_rx_buf();
     }
 }
 

--- a/src/transceiver.h
+++ b/src/transceiver.h
@@ -58,9 +58,9 @@ boot = 0b0 (application mode)
 */
 #define TRANS_DEF_SCW   0x0303
 
-// Default frequency
-// This is in the 32-bit format, i.e. the output of EnduroSat's utility program
-#define TRANS_DEF_FREQ 0x76620F41UL // TODO - what is this frequency?
+// Default frequency (435MHz, p.6)
+// This is in the 32-bit format, i.e. from the output of EnduroSat's utility program
+#define TRANS_DEF_FREQ 0x76620F41UL
 
 // Default beacon parameters
 #define TRANS_BEACON_DEF_PERIOD_S   60

--- a/src/transceiver.h
+++ b/src/transceiver.h
@@ -95,6 +95,9 @@ extern volatile uint8_t    trans_tx_enc_msg[];
 extern volatile uint8_t    trans_tx_enc_len;
 extern volatile bool       trans_tx_enc_avail;
 
+extern bool print_trans_msgs;
+
+
 // Initialization
 void init_trans(void);
 void init_trans_uart(void);


### PR DESCRIPTION
- Add necessary constants for statuses
- Write data block fields as they are received, rather than at the end
- Write header status byte separately, at the end of a command or when it times out
- Move printing of packets, CAN, ACKs, etc. to main code with enable variables